### PR TITLE
use rand_r instead of rand for multithreading purposes

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -32,11 +32,7 @@ extern struct poly *polygonArray;
  @return Error codes, 0 if exited normally
  */
 int main(int argc, char *argv[]) {
-	//Seed RNGs
-	srand((int)time(NULL));
-#ifndef WINDOWS
-	srand48(time(NULL));
-#endif
+
 	
 	initTerminal();
 	

--- a/src/tile.c
+++ b/src/tile.c
@@ -117,13 +117,15 @@ unsigned int rand_interval(unsigned int min, unsigned int max) {
 	const unsigned int range = 1 + max - min;
 	const unsigned int buckets = RAND_MAX / range;
 	const unsigned int limit = buckets * range;
+
+	unsigned int seed = time(NULL);
 	
 	/* Create equal size buckets all in a row, then fire randomly towards
 	 * the buckets until you land in one of them. All buckets are equally
 	 * likely. If you land off the end of the line of buckets, try again. */
 	do
 	{
-		r = rand();
+		r = rand_r(&seed);
 	} while (r >= limit);
 	
 	return min + (r / buckets);

--- a/src/vector.c
+++ b/src/vector.c
@@ -191,7 +191,8 @@ struct coord uvFromValues(double u, double v) {
  @return Random double between min and max
  */
 double getRandomDouble(double min, double max) {
-	return ((((double)rand()) / (double)RAND_MAX) * (max - min)) + min;
+	unsigned int seed = time(NULL);
+	return ((((double)rand_r(&seed)) / (double)RAND_MAX) * (max - min)) + min;
 }
 
 /**


### PR DESCRIPTION
This solves, at least for me, an issue where a lot of time was spent in kernel land and not generating the scene. Performance has increased tremendously due to this change.

**NOTE** This generates a broken scene.