### PR TITLE
Fix segmentation fault at exit

### DIFF
--- a/src/utils/loaders/sceneloader.c
+++ b/src/utils/loaders/sceneloader.c
@@ -440,6 +440,10 @@ struct transform *parseTransforms(const cJSON *data) {
 }
 
 struct prefs defaultPrefs() {
+    char* imgFilePath;
+    char* imgFileName;
+    copyString("./", &imgFilePath);
+    copyString("rendered", &imgFileName);
 	return (struct prefs){
 		.tileOrder = renderOrderFromMiddle,
 		.threadCount = getSysCores(), //We run getSysCores() for this
@@ -448,8 +452,8 @@ struct prefs defaultPrefs() {
 		.tileWidth = 32,
 		.tileHeight = 32,
 		.antialiasing = true,
-		.imgFilePath = "./",
-		.imgFileName = "rendered",
+		.imgFilePath = imgFilePath,
+		.imgFileName = imgFileName,
 		.imgCount = 0,
 		.imageWidth = 1280,
 		.imageHeight = 800,

--- a/src/utils/loaders/sceneloader.c
+++ b/src/utils/loaders/sceneloader.c
@@ -440,10 +440,10 @@ struct transform *parseTransforms(const cJSON *data) {
 }
 
 struct prefs defaultPrefs() {
-    char* imgFilePath;
-    char* imgFileName;
-    copyString("./", &imgFilePath);
-    copyString("rendered", &imgFileName);
+	char* imgFilePath;
+	char* imgFileName;
+	copyString("./", &imgFilePath);
+	copyString("rendered", &imgFileName);
 	return (struct prefs){
 		.tileOrder = renderOrderFromMiddle,
 		.threadCount = getSysCores(), //We run getSysCores() for this


### PR DESCRIPTION
This commit fixes a segmentation fault happening upon program exit. The code could be improved by making `copyString` _return_ the new string instead of modifying an existing string pointer (or using `strdup`, as it's apparently going to be standardized in C2x). Also note that `free` already tests that the argument is not `NULL` and that thus, pretty much all calls to `free` that look like:
```
if (ptr)
  free(ptr);
```
can just be replaced with:
```
free(ptr);
```
In any case, this commit does _not_ apply those stylistic changes: These are suggestions and feel free not to apply them if you don't like them.