### PR TITLE
Binned SAH BVH builder

### DIFF
--- a/src/accelerators/bvh.c
+++ b/src/accelerators/bvh.c
@@ -1,0 +1,404 @@
+#include "../includes.h"
+#include "bvh.h"
+
+#include "../renderer/pathtrace.h"
+
+#include "../datatypes/vertexbuffer.h"
+#include "../datatypes/poly.h"
+#include "../datatypes/vector.h"
+#include "../datatypes/lightRay.h"
+
+/*
+ * This BVH builder is based on "On fast Construction of SAH-based Bounding Volume Hierarchies",
+ * by I. Wald. The general idea is to approximate the SAH by subdividing each axis in several
+ * bins. Primitives are then placed into those bins according to their centers, and then the
+ * split is found by sweeping the bin array to find the partition with the lowest SAH.
+ * The algorithm needs only a bounding box and a center per primitive, which allows to build
+ * BVHs out of any primitive type, including other BVHs (necessary for instancing).
+ */
+
+#define MAX_BVH_DEPTH  64   // This should be enough for most scenes
+#define MAX_LEAF_SIZE  16   // Maximum number of primitives per leaf (used to avoid cases where the SAH gets "stuck")
+#define TRAVERSAL_COST 1.5f // Ratio (cost of traversing a node / cost of intersecting a primitive)
+#define BIN_COUNT      32   // Number of bins to use to approximate the SAH
+
+// TODO: Move this to its own file if need be
+// NOTE: The existing `boundingBox` type is too big
+typedef struct bBox {
+	vector min, max;
+} bBox;
+
+// Bin used to approximate the SAH.
+typedef struct Bin {
+	bBox bbox;
+	unsigned count;
+	float cost;
+} Bin;
+
+static inline void storeBBoxInNode(struct bvhNode *node, const bBox *bbox) {
+	node->bounds[0] = bbox->min.x;
+	node->bounds[1] = bbox->max.x;
+	node->bounds[2] = bbox->min.y;
+	node->bounds[3] = bbox->max.y;
+	node->bounds[4] = bbox->min.z;
+	node->bounds[5] = bbox->max.z;
+}
+
+static inline void loadBBoxFromNode(bBox *bbox, const struct bvhNode *node) {
+	bbox->min.x = node->bounds[0];
+	bbox->max.x = node->bounds[1];
+	bbox->min.y = node->bounds[2];
+	bbox->max.y = node->bounds[3];
+	bbox->min.z = node->bounds[4];
+	bbox->max.z = node->bounds[5];
+}
+
+static const bBox emptyBBox = {
+	.min = {  FLT_MAX,  FLT_MAX,  FLT_MAX },
+	.max = { -FLT_MAX, -FLT_MAX, -FLT_MAX }
+};
+
+static inline float halfArea(const bBox *bbox) {
+	vector extent = vecSub(bbox->max, bbox->min);
+	return extent.x * (extent.y + extent.z) + extent.y * extent.z;
+}
+
+static inline void extendBBox(bBox *dst, const bBox *src) {
+	dst->min = vecMin(dst->min, src->min);
+	dst->max = vecMax(dst->max, src->max);
+}
+
+static inline float nodeArea(const struct bvhNode *node) {
+	bBox bbox;
+	loadBBoxFromNode(&bbox, node);
+	return halfArea(&bbox);
+}
+
+static inline void makeLeaf(struct bvhNode* node, unsigned begin, unsigned primCount) {
+	node->isLeaf = true;
+	node->firstChildOrPrim = begin;
+	node->primCount = primCount;
+}
+
+static inline unsigned computeBinIndex(int axis, const vector *center, float min, float max) {
+	float centerToBin = BIN_COUNT / (max - min);
+	float coord = axis == 0 ? center->x : (axis == 1 ? center->y : center->z);
+	float floatIndex = (coord - min) * centerToBin;
+	unsigned binIndex = floatIndex < 0 ? 0 : floatIndex;
+	return binIndex >= BIN_COUNT ? BIN_COUNT - 1 : binIndex;
+}
+
+static inline unsigned partitionPrimitiveIndices(
+	const struct bvhNode *node,
+	const struct bvh *bvh,
+	const vector *centers,
+	unsigned axis, unsigned bin,
+	unsigned begin, unsigned end)
+{
+	// Perform the split by partitioning primitive indices in-place
+	unsigned i = begin, j = end;
+	while (i < j) {
+		while (i < j) {
+			unsigned binIndex = computeBinIndex(axis, &centers[bvh->primIndices[i]], node->bounds[axis * 2], node->bounds[axis * 2 + 1]);
+			if (binIndex >= bin)
+				break;
+			i++;
+		}
+
+		while (i < j) {
+			unsigned binIndex = computeBinIndex(axis, &centers[bvh->primIndices[j - 1]], node->bounds[axis * 2], node->bounds[axis * 2 + 1]);
+			if (binIndex < bin)
+				break;
+			j--;
+		}
+
+		if (i >= j)
+			break;
+
+		int tmp = bvh->primIndices[j - 1];
+		bvh->primIndices[j - 1] = bvh->primIndices[i];
+		bvh->primIndices[i] = tmp;
+
+		j--;
+		i++;
+	}
+	return i;
+}
+
+static void buildBvhRecursive(
+	unsigned nodeId,
+	struct bvh *bvh,
+	const bBox *bboxes,
+	const vector *centers,
+	unsigned begin, unsigned end,
+	unsigned depth)
+{
+	unsigned primCount = end - begin;
+	struct bvhNode *node = &bvh->nodes[nodeId];
+
+	if (depth >= MAX_BVH_DEPTH || primCount < 2) {
+		makeLeaf(node, begin, primCount);
+		return;
+	}
+
+	Bin bins[3][BIN_COUNT];
+	float minCost[3] = { FLT_MAX, FLT_MAX, FLT_MAX };
+	unsigned minBin[3] = { 1, 1, 1 };
+	for (int axis = 0; axis < 3; ++axis) {
+		// Initialize bins
+		for (int i = 0; i < BIN_COUNT; ++i) {
+			bins[axis][i].bbox = emptyBBox;
+			bins[axis][i].count = 0;
+		}
+
+		// Fill bins with primitives
+		for (unsigned i = begin; i < end; ++i) {
+			int primIndex = bvh->primIndices[i];
+			unsigned binIndex = computeBinIndex(axis, &centers[primIndex], node->bounds[axis * 2], node->bounds[axis * 2 + 1]);
+			Bin *bin = &bins[axis][binIndex];
+			extendBBox(&bin->bbox, &bboxes[primIndex]);
+			bin->count++;
+		}
+
+		// Sweep from the right to the left to compute the partial SAH cost.
+		// Recall that the SAH is the sum of two parts: SA(left) * N(left) + SA(right) * N(right).
+		// This loop computes SA(right) * N(right) alone.
+		bBox curBBox = emptyBBox;
+		unsigned curCount = 0;
+		for (unsigned i = BIN_COUNT; i > 1; --i) {
+			Bin *bin = &bins[axis][i - 1];
+			curCount += bin->count;
+			extendBBox(&curBBox, &bin->bbox);
+			bin->cost = curCount * halfArea(&curBBox);
+		}
+
+		// Sweep from the left to the right to compute the full cost and find the minimum.
+		curBBox = emptyBBox;
+		curCount = 0;
+		for (unsigned i = 0; i < BIN_COUNT - 1; i++) {
+			Bin *bin = &bins[axis][i];
+			curCount += bin->count;
+			extendBBox(&curBBox, &bin->bbox);
+			float cost = curCount * halfArea(&curBBox) + bins[axis][i + 1].cost;
+			if (cost < minCost[axis]) {
+				minBin[axis] = i + 1;
+				minCost[axis] = cost;
+			}
+		}
+	}
+
+	// Find the minimum cost for all three axes
+	unsigned minAxis = 0;
+	if (minCost[1] < minCost[0]) minAxis = 1;
+	if (minCost[2] < minCost[minAxis]) minAxis = 2;
+
+	// Determine if splitting is beneficial or not
+	float leafCost = nodeArea(node) * (primCount - TRAVERSAL_COST);
+	if (minCost[minAxis] > leafCost) {
+		if (primCount > MAX_LEAF_SIZE) {
+			// Fallback strategy to avoid large leaves: Approximate median split
+			for (unsigned i = 0, accumCount = 0, bestApprox = primCount; i < BIN_COUNT - 1; ++i) {
+				accumCount += bins[minAxis][i].count;
+				unsigned approx = abs((int)primCount/2 - (int)accumCount);
+				if (approx < bestApprox) {
+					bestApprox = approx;
+					minBin[minAxis] = i + 1;
+				}
+			}
+		} else {
+			makeLeaf(node, begin, primCount);
+			return;
+		}
+	}
+
+	// Perform the split by partitioning primitive indices in-place
+	unsigned beginRight = partitionPrimitiveIndices(node, bvh, centers, minAxis, minBin[minAxis], begin, end);
+	if (beginRight > begin) {
+		unsigned leftIndex = bvh->nodeCount;
+		unsigned rightIndex = leftIndex + 1;
+		bvh->nodeCount += 2;
+
+		// Compute the bounding box of the children
+		bBox leftBBox = emptyBBox;
+		bBox rightBBox = emptyBBox;
+		for (unsigned i = 0; i < minBin[minAxis]; ++i)
+			extendBBox(&leftBBox, &bins[minAxis][i].bbox);
+		for (unsigned i = minBin[minAxis]; i < BIN_COUNT; ++i)
+			extendBBox(&rightBBox, &bins[minAxis][i].bbox);
+		storeBBoxInNode(&bvh->nodes[leftIndex], &leftBBox);
+		storeBBoxInNode(&bvh->nodes[rightIndex], &rightBBox);
+		node->firstChildOrPrim = leftIndex;
+		node->isLeaf = false;
+
+		buildBvhRecursive(leftIndex, bvh, bboxes, centers, begin, beginRight, depth + 1);
+		buildBvhRecursive(rightIndex, bvh, bboxes, centers, beginRight, end, depth + 1);
+	} else {
+		makeLeaf(node, begin, primCount);
+	}
+}
+
+struct bvh *buildBvh(int *polys, unsigned count) {
+	vector *centers = malloc(sizeof(vector) * count);
+	bBox *bboxes = malloc(sizeof(bBox) * count);
+	int *primIndices = malloc(sizeof(int) * count);
+
+	bBox rootBBox = emptyBBox;
+
+	// Precompute bboxes and centers
+	for (unsigned i = 0; i < count; ++i) {
+		vector v0 = vertexArray[polygonArray[polys[i]].vertexIndex[0]];
+		vector v1 = vertexArray[polygonArray[polys[i]].vertexIndex[1]];
+		vector v2 = vertexArray[polygonArray[polys[i]].vertexIndex[2]];
+		centers[i] = getMidPoint(v0, v1, v2);
+		bboxes[i].min = vecMin(v0, vecMin(v1, v2));
+		bboxes[i].max = vecMax(v0, vecMax(v1, v2));
+		primIndices[i] = i;
+		rootBBox.min = vecMin(rootBBox.min, bboxes[i].min);
+		rootBBox.max = vecMax(rootBBox.max, bboxes[i].max);
+	}
+
+	// Binary tree property: total number of nodes (inner + leaves) = 2 * number of leaves - 1
+	unsigned maxNodes = 2 * count - 1;
+
+	struct bvh *bvh = malloc(sizeof(struct bvh));
+	bvh->nodeCount = 1;
+	bvh->nodes = malloc(sizeof(struct bvhNode) * maxNodes);
+	bvh->primIndices = primIndices;
+	storeBBoxInNode(&bvh->nodes[0], &rootBBox);
+
+	buildBvhRecursive(0, bvh, bboxes, centers, 0, count, 0);
+
+	// Shrink array of nodes (since some leaves may contain more than 1 primitive)
+	bvh->nodes = realloc(bvh->nodes, sizeof(struct bvhNode) * bvh->nodeCount);
+	for (unsigned i = 0; i < count; ++i)
+		primIndices[i] = polys[primIndices[i]];
+	free(centers);
+	free(bboxes);
+	return bvh;
+}
+
+static inline bool rayIntersectsWithBvhLeaf(const struct bvh *bvh, const struct bvhNode *leaf, const struct lightRay *ray, struct hitRecord *isect) {
+	bool found = false;
+	for (int i = 0; i < leaf->primCount; ++i) {
+		struct poly p = polygonArray[bvh->primIndices[leaf->firstChildOrPrim + i]];
+		if (rayIntersectsWithPolygon(ray, &p, &isect->distance, &isect->surfaceNormal, &isect->uv)) {
+			isect->didIntersect = true;
+			isect->type = hitTypePolygon;
+			isect->polyIndex = p.polyIndex;
+			found = true;
+		}
+	}
+	return found;
+}
+
+static inline float fastMultiplyAdd(float a, float b, float c) {
+#ifdef FP_FAST_FMAF
+	return fmaf(a, b, c);
+#else
+	return a * b + c;
+#endif
+}
+
+static inline bool rayIntersectsWithBvhNode(
+	const struct bvhNode *node,
+	const vector *invDir,
+	const vector *scaledStart,
+	int ox, int oy, int oz,
+	float maxDist,
+	float* tEntry)
+{
+	float tMinX = fastMultiplyAdd(node->bounds[0 * 2 +     ox], invDir->x, scaledStart->x);
+	float tMaxX = fastMultiplyAdd(node->bounds[0 * 2 + 1 - ox], invDir->x, scaledStart->x);
+	float tMinY = fastMultiplyAdd(node->bounds[1 * 2 +     oy], invDir->y, scaledStart->y);
+	float tMaxY = fastMultiplyAdd(node->bounds[1 * 2 + 1 - oy], invDir->y, scaledStart->y);
+	float tMinZ = fastMultiplyAdd(node->bounds[2 * 2 +     oz], invDir->z, scaledStart->z);
+	float tMaxZ = fastMultiplyAdd(node->bounds[2 * 2 + 1 - oz], invDir->z, scaledStart->z);
+	// Note the order here is important.
+	// Because the comparisons are of the form x < y ? x : y, they
+	// are guaranteed not to produce NaNs if the right hand side is not a NaN.
+	float tMin = tMinX > tMinY ? tMinX : tMinY;
+	float tMax = tMaxX < tMaxY ? tMaxX : tMaxY;
+	tMin = tMin > tMinZ ? tMin : tMinZ;
+	tMax = tMax < tMaxZ ? tMax : tMaxZ;
+	// TODO: Add [tmin, tmax] to the lightRay structure for more efficient culling.
+	tMin = tMin > 0 ? tMin : 0;
+	tMax = tMax < maxDist ? tMax : maxDist;
+	*tEntry = tMin;
+	return tMin <= tMax;
+}
+
+bool rayIntersectsWithBvh(const struct bvh *bvh, const struct lightRay *ray, struct hitRecord *isect) {
+	const struct bvhNode *stack[MAX_BVH_DEPTH + 1];
+	int stackSize = 0;
+
+	// Special case when the BVH is just a single leaf
+	if (bvh->nodeCount == 1)
+		return rayIntersectsWithBvhLeaf(bvh, bvh->nodes, ray, isect);
+
+	// Precompute ray octant and inverse direction
+	int ox = ray->direction.x < 0 ? 1 : 0;
+	int oy = ray->direction.y < 0 ? 1 : 0;
+	int oz = ray->direction.z < 0 ? 1 : 0;
+	vector invDir = { 1.0f / ray->direction.x, 1.0f / ray->direction.y, 1.0f / ray->direction.z };
+	vector scaledStart = vecScale(vecMul(ray->start, invDir), -1.0f);
+
+	const struct bvhNode *node = bvh->nodes;
+	float maxDist = isect->didIntersect ? isect->distance : FLT_MAX;
+	bool hasHit = false;
+	while (true) {
+		unsigned firstChild = node->firstChildOrPrim;
+		const struct bvhNode *leftNode  = &bvh->nodes[firstChild];
+		const struct bvhNode *rightNode = &bvh->nodes[firstChild + 1];
+
+		float tEntryLeft, tEntryRight;
+		bool hitLeft = rayIntersectsWithBvhNode(leftNode, &invDir, &scaledStart, ox, oy, oz, maxDist, &tEntryLeft);
+		bool hitRight = rayIntersectsWithBvhNode(rightNode, &invDir, &scaledStart, ox, oy, oz, maxDist, &tEntryRight);
+
+		if (hitLeft) {
+			if (leftNode->isLeaf) {
+				if (rayIntersectsWithBvhLeaf(bvh, leftNode, ray, isect)) {
+					maxDist = isect->distance;
+					hasHit = true;
+				}
+				leftNode = NULL;
+			}
+		} else
+			leftNode = NULL;
+
+		if (hitRight) {
+			if (rightNode->isLeaf) {
+				if (rayIntersectsWithBvhLeaf(bvh, rightNode, ray, isect)) {
+					maxDist = isect->distance;
+					hasHit = true;
+				}
+				rightNode = NULL;
+			}
+		} else
+			rightNode = NULL;
+
+		if ((rightNode != NULL) & (leftNode != NULL)) {
+			// Choose the child that is the closest, and push the other on the stack.
+			if (tEntryLeft > tEntryRight) {
+				node = leftNode;
+				leftNode = rightNode;
+				rightNode = node;
+			}
+			node = leftNode;
+			stack[stackSize++] = rightNode;
+		} else if ((rightNode != NULL) ^ (leftNode != NULL)) {
+			// Only one child needs traversal
+			node = rightNode != NULL ? rightNode : leftNode;
+		} else {
+			if (stackSize == 0)
+				break;
+			node = stack[--stackSize];
+		}
+	}
+	return hasHit;
+}
+
+void destroyBvh(struct bvh *bvh) {
+	free(bvh->nodes);
+	free(bvh->primIndices);
+	free(bvh);
+}

--- a/src/accelerators/bvh.h
+++ b/src/accelerators/bvh.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <stdbool.h>
+
+struct lightRay;
+struct hitRecord;
+
+struct bvhNode {
+	float bounds[6]; // Node bounds (min x, max x, min y, max y, ...)
+	unsigned firstChildOrPrim; // Index to the first child or primitive (if the node is a leaf)
+	unsigned primCount : 30;
+	bool isLeaf : 1;
+};
+
+struct bvh {
+	struct bvhNode* nodes;
+	int *primIndices;
+	unsigned nodeCount;
+};
+
+/// Builds a BVH
+/// @param polygons Array of polygons to process
+/// @param count Amount of polygons given
+struct bvh *buildBvh(int *polygons, unsigned count);
+
+/// Intersects a ray with the given BVH
+bool rayIntersectsWithBvh(const struct bvh *bvh, const struct lightRay *ray, struct hitRecord *isect);
+
+/// Frees the memory allocated by the given BVH
+void destroyBvh(struct bvh *);

--- a/src/datatypes/mesh.c
+++ b/src/datatypes/mesh.c
@@ -10,6 +10,7 @@
 #include "mesh.h"
 
 #include "../accelerators/kdtree.h"
+#include "../accelerators/bvh.h"
 #include "vertexbuffer.h"
 #include "transforms.h"
 #include "poly.h"
@@ -67,9 +68,15 @@ void destroyMesh(struct mesh *mesh) {
 			free(mesh->transforms);
 		}
 	}
+#ifdef OLD_KD_TREE
 	if (mesh->tree) {
 		destroyTree(mesh->tree);
 	}
+#else
+	if (mesh->bvh) {
+		destroyBvh(mesh->bvh);
+	}
+#endif
 	if (mesh->materials) {
 		for (int i = 0; i < mesh->materialCount; ++i) {
 			destroyMaterial(&mesh->materials[i]);

--- a/src/datatypes/mesh.h
+++ b/src/datatypes/mesh.h
@@ -42,8 +42,12 @@ struct mesh {
 	int materialCount;
 	struct material *materials;
 	
+#ifdef OLD_KD_TREE
 	//Root node of the kd-tree for this mesh
 	struct kdTreeNode *tree;
+#else
+	struct bvh *bvh;
+#endif
 	
 	char *name;
 };

--- a/src/renderer/pathtrace.c
+++ b/src/renderer/pathtrace.c
@@ -13,6 +13,7 @@
 #include "../datatypes/camera.h"
 #include "../accelerators/bbox.h"
 #include "../accelerators/kdtree.h"
+#include "../accelerators/bvh.h"
 #include "../datatypes/image/texture.h"
 #include "../datatypes/image/hdr.h"
 #include "../datatypes/vertexbuffer.h"
@@ -107,7 +108,11 @@ struct hitRecord getClosestIsect(const struct lightRay *incidentRay, const struc
 		}
 	}
 	for (int o = 0; o < scene->meshCount; ++o) {
+#ifdef OLD_KD_TREE
 		if (rayIntersectsWithNode(scene->meshes[o].tree, incidentRay, &isect)) {
+#else
+		if (rayIntersectsWithBvh(scene->meshes[o].bvh, incidentRay, &isect)) {
+#endif
 			isect.end = scene->meshes[o].materials[polygonArray[isect.polyIndex].materialIndex];
 			computeSurfaceProps(polygonArray[isect.polyIndex], isect.uv, &isect.hitPoint, &isect.surfaceNormal);
 			

--- a/src/utils/loaders/sceneloader.c
+++ b/src/utils/loaders/sceneloader.c
@@ -440,6 +440,10 @@ struct transform *parseTransforms(const cJSON *data) {
 }
 
 struct prefs defaultPrefs() {
+    char* imgFilePath;
+    char* imgFileName;
+    copyString("./", &imgFilePath);
+    copyString("rendered", &imgFileName);
 	return (struct prefs){
 		.tileOrder = renderOrderFromMiddle,
 		.threadCount = getSysCores(), //We run getSysCores() for this
@@ -448,8 +452,8 @@ struct prefs defaultPrefs() {
 		.tileWidth = 32,
 		.tileHeight = 32,
 		.antialiasing = true,
-		.imgFilePath = "./",
-		.imgFileName = "rendered",
+		.imgFilePath = imgFilePath,
+		.imgFileName = imgFileName,
 		.imgCount = 0,
 		.imageWidth = 1280,
 		.imageHeight = 800,

--- a/src/utils/loaders/sceneloader.c
+++ b/src/utils/loaders/sceneloader.c
@@ -440,10 +440,10 @@ struct transform *parseTransforms(const cJSON *data) {
 }
 
 struct prefs defaultPrefs() {
-    char* imgFilePath;
-    char* imgFileName;
-    copyString("./", &imgFilePath);
-    copyString("rendered", &imgFileName);
+	char* imgFilePath;
+	char* imgFileName;
+	copyString("./", &imgFilePath);
+	copyString("rendered", &imgFileName);
 	return (struct prefs){
 		.tileOrder = renderOrderFromMiddle,
 		.threadCount = getSysCores(), //We run getSysCores() for this


### PR DESCRIPTION
This PR implements a Binned SAH BVH builder, based on "On fast Construction of SAH-based Bounding Volume Hierarchies", by I. Wald. The existing Kd-tree/BVH implementation has been kept intact for comparison purposes. It can be enabled again by defining the preprocessor symbol `OLD_KD_TREE`.

I have only the provided test scene to measure performance, and I cannot really tell if there's a measurable performance improvement because:

 - More than 40% of the time is spent in small functions like `vecSub`. Ray traversal is only 4% of the execution time. Thus, even if this made traversal infinitely faster, not much of an improvement would be visible. This is due to the way you organized your code, as most of those small functions are in separate compilation units and unavailable for the inliner. You have basically two options to fix this problem: Use LTO (on my machine it multiplies performance by almost 3), or move these small functions into their respective header file with the `static inline` qualifiers to avoid linking problems (I would recommend going that route, as it gives you more control over what is inlined and what isn't, and doesn't blow up your compilation times).
To enable LTO, you can bump your CMake requirement to something more modern (e.g. 3.4) and use the following:
```set_property(TARGET c-ray PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)```
Note that this _will not_ work on old CMake versions (e.g. 2.8 will not enable LTO for gcc). If you want to use LTO but stick to an old CMake version, you need to append `-flto` to both the linker and compiler flags for gcc (old versions of gcc might not support LTO).

 - The second problem is that the test scene you provide has around 10 meshes that each have their own BVH, but all are traversed sequentially, completely nullifying the benefit of using an acceleration data structure altogether. I recommend to either merge those meshes, or to build a top-level BVH that has per-mesh BVHs as leaves. The code in this PR is designed to be able to do that, as only bounding boxes and centers are required to build a BVH (so it works for any primitive type, including other BVHs).

Finally, there's a large optimization potential that's not taken advantage of, namely early exit for shadow rays. For that, I have added a `TODO` that suggests to add a `tMin` and `tMax` to your rays, so that you can actually cull nodes more efficiently during traversal (because shadow rays can exit the traversal loop early, upon the first intersection found in the given `[tMin, tMax]` range). This in general gives a 20% performance boost when implemented correctly. This PR does not implement  this feature, as it would break the compatibility with the existing acceleration data structure.