### PR TITLE
Fix top-level BVH implementation

### DIFF
--- a/src/accelerators/bvh.c
+++ b/src/accelerators/bvh.c
@@ -320,12 +320,12 @@ static inline bool intersectNode(
 	float maxDist,
 	float* tEntry)
 {
-	float tMinX = fastMultiplyAdd(node->bounds[0 * 2 +     octant[0]], invDir->x, scaledStart->x);
-	float tMaxX = fastMultiplyAdd(node->bounds[0 * 2 + 1 - octant[0]], invDir->x, scaledStart->x);
-	float tMinY = fastMultiplyAdd(node->bounds[1 * 2 +     octant[1]], invDir->y, scaledStart->y);
-	float tMaxY = fastMultiplyAdd(node->bounds[1 * 2 + 1 - octant[1]], invDir->y, scaledStart->y);
-	float tMinZ = fastMultiplyAdd(node->bounds[2 * 2 +     octant[2]], invDir->z, scaledStart->z);
-	float tMaxZ = fastMultiplyAdd(node->bounds[2 * 2 + 1 - octant[2]], invDir->z, scaledStart->z);
+	float tMinX = fastMultiplyAdd((node->bounds + 0)[    octant[0]], invDir->x, scaledStart->x);
+	float tMaxX = fastMultiplyAdd((node->bounds + 0)[1 - octant[0]], invDir->x, scaledStart->x);
+	float tMinY = fastMultiplyAdd((node->bounds + 2)[    octant[1]], invDir->y, scaledStart->y);
+	float tMaxY = fastMultiplyAdd((node->bounds + 2)[1 - octant[1]], invDir->y, scaledStart->y);
+	float tMinZ = fastMultiplyAdd((node->bounds + 4)[    octant[2]], invDir->z, scaledStart->z);
+	float tMaxZ = fastMultiplyAdd((node->bounds + 4)[1 - octant[2]], invDir->z, scaledStart->z);
 	// Note the order here is important.
 	// Because the comparisons are of the form x < y ? x : y, they
 	// are guaranteed not to produce NaNs if the right hand side is not a NaN.
@@ -379,7 +379,7 @@ static inline bool traverseBvhGeneric(
 		bool hitRight = intersectNode(rightNode, &invDir, &scaledStart, octant, maxDist, &tEntryRight);
 
 		if (hitLeft) {
-			if (leftNode->isLeaf) {
+			if (unlikely(leftNode->isLeaf)) {
 				if (intersectLeaf(userData, bvh, leftNode, ray, isect)) {
 					maxDist = isect->distance;
 					hasHit = true;
@@ -390,7 +390,7 @@ static inline bool traverseBvhGeneric(
 			leftNode = NULL;
 
 		if (hitRight) {
-			if (rightNode->isLeaf) {
+			if (unlikely(rightNode->isLeaf)) {
 				if (intersectLeaf(userData, bvh, rightNode, ray, isect)) {
 					maxDist = isect->distance;
 					hasHit = true;

--- a/src/accelerators/bvh.c
+++ b/src/accelerators/bvh.c
@@ -320,12 +320,12 @@ static inline bool intersectNode(
 	float maxDist,
 	float* tEntry)
 {
-	float tMinX = fastMultiplyAdd((node->bounds + 0)[    octant[0]], invDir->x, scaledStart->x);
-	float tMaxX = fastMultiplyAdd((node->bounds + 0)[1 - octant[0]], invDir->x, scaledStart->x);
-	float tMinY = fastMultiplyAdd((node->bounds + 2)[    octant[1]], invDir->y, scaledStart->y);
-	float tMaxY = fastMultiplyAdd((node->bounds + 2)[1 - octant[1]], invDir->y, scaledStart->y);
-	float tMinZ = fastMultiplyAdd((node->bounds + 4)[    octant[2]], invDir->z, scaledStart->z);
-	float tMaxZ = fastMultiplyAdd((node->bounds + 4)[1 - octant[2]], invDir->z, scaledStart->z);
+	float tMinX = fastMultiplyAdd(node->bounds[0 +     octant[0]], invDir->x, scaledStart->x);
+	float tMaxX = fastMultiplyAdd(node->bounds[0 + 1 - octant[0]], invDir->x, scaledStart->x);
+	float tMinY = fastMultiplyAdd(node->bounds[2 +     octant[1]], invDir->y, scaledStart->y);
+	float tMaxY = fastMultiplyAdd(node->bounds[2 + 1 - octant[1]], invDir->y, scaledStart->y);
+	float tMinZ = fastMultiplyAdd(node->bounds[4 +     octant[2]], invDir->z, scaledStart->z);
+	float tMaxZ = fastMultiplyAdd(node->bounds[4 + 1 - octant[2]], invDir->z, scaledStart->z);
 	// Note the order here is important.
 	// Because the comparisons are of the form x < y ? x : y, they
 	// are guaranteed not to produce NaNs if the right hand side is not a NaN.

--- a/src/accelerators/bvh.h
+++ b/src/accelerators/bvh.h
@@ -27,7 +27,7 @@ struct bvh *buildBottomLevelBvh(int *polygons, unsigned count);
 struct bvh *buildTopLevelBvh(struct mesh *meshes, unsigned meshCount);
 
 /// Intersect a ray with a scene top-level BVH
-bool traverseTopLevelBvh(const struct bvh *bvh, const struct lightRay *ray, struct hitRecord *isect);
+bool traverseTopLevelBvh(const struct mesh *meshes, const struct bvh *bvh, const struct lightRay *ray, struct hitRecord *isect);
 
 /// Frees the memory allocated by the given BVH
 void destroyBvh(struct bvh *);

--- a/src/includes.h
+++ b/src/includes.h
@@ -19,6 +19,13 @@
 #define min(a,b) (((a) < (b)) ? (a) : (b))
 #define max(a,b) (((a) > (b)) ? (a) : (b))
 #define invsqrt(x) (1.0f / sqrtf(x))
+#if defined(__GNUC__) || defined(__clang__)
+#define unlikely(x) __builtin_expect(x, false)
+#define likely(x)   __builtin_expect(x, true)
+#else
+#define unlikely(x) (x)
+#define likely(x)   (x)
+#endif
 
 //Master include file
 #ifdef __linux__

--- a/src/renderer/pathtrace.c
+++ b/src/renderer/pathtrace.c
@@ -112,27 +112,14 @@ struct hitRecord getClosestIsect(const struct lightRay *incidentRay, const struc
 			isect.didIntersect = true;
 		}
 	}
-	
-	if (traverseTopLevelBvh(scene->topLevel, incidentRay, &isect)) {
+
+	if (traverseTopLevelBvh(scene->meshes, scene->topLevel, incidentRay, &isect)) {
 		isect.end = scene->meshes[polygonArray[isect.polyIndex].meshIndex].materials[polygonArray[isect.polyIndex].materialIndex];
 		computeSurfaceProps(polygonArray[isect.polyIndex], isect.uv, &isect.hitPoint, &isect.surfaceNormal);
 		if (isect.end.hasNormalMap)
 			isect.surfaceNormal = bumpmap(&isect);
 		isect.didIntersect = true;
 	}
-	
-	/*for (int o = 0; o < scene->meshCount; ++o) {
-		if (rayIntersectsWithBottomLevelBvh(scene->meshes[o].bvh, incidentRay, &isect)) {
-			isect.end = scene->meshes[o].materials[polygonArray[isect.polyIndex].materialIndex];
-			computeSurfaceProps(polygonArray[isect.polyIndex], isect.uv, &isect.hitPoint, &isect.surfaceNormal);
-			
-			if (isect.end.hasNormalMap) {
-				isect.surfaceNormal = bumpmap(&isect);
-			}
-			
-			isect.didIntersect = true;
-		}
-	}*/
 	return isect;
 }
 

--- a/src/renderer/pathtrace.c
+++ b/src/renderer/pathtrace.c
@@ -118,7 +118,6 @@ struct hitRecord getClosestIsect(const struct lightRay *incidentRay, const struc
 		computeSurfaceProps(polygonArray[isect.polyIndex], isect.uv, &isect.hitPoint, &isect.surfaceNormal);
 		if (isect.end.hasNormalMap)
 			isect.surfaceNormal = bumpmap(&isect);
-		isect.didIntersect = true;
 	}
 	return isect;
 }


### PR DESCRIPTION
This fixes the top-level BVH implementation and enables it during rendering. A couple of additional notes:
- I'm not sure about having a global polygon array. Why not have this be part of the mesh? After all, each mesh owns its polygon array, so having global data there is strange.
- If the remark above is taken care of, then callbacks in the BVH can be simplified by having their user data being the scene for the top-level, and a mesh for the bottom level.
- You can strip the `meshIndex` and `polyIndex` out of the `poly` structure. Just add a `meshIndex` to the `hitRecord` and let the BVH set it when it iterates over the meshes contained in a top-level leaf. The same can be said for the bottom-level leaves and the `polyIndex` member.