### PR TITLE
Place instances in BVH

### DIFF
--- a/src/accelerators/bvh.c
+++ b/src/accelerators/bvh.c
@@ -298,8 +298,7 @@ struct bvh *buildBottomLevelBvh(struct poly *polys, unsigned count) {
 
 static void getInstanceBBoxAndCenter(void *userData, unsigned i, struct boundingBox *bbox, struct vector *center) {
 	struct instance *instances = userData;
-	instances[i].getBBoxAndCenterFn(instances[i].object, bbox, center);
-	transformBBox(bbox, &instances[i].composite.A);
+	instances[i].getBBoxAndCenterFn(&instances[i], bbox, center);
 }
 
 struct bvh *buildTopLevelBvh(struct instance *instances, unsigned instanceCount) {
@@ -458,13 +457,7 @@ static inline bool intersectTopLevelLeaf(
 	bool found = false;
 	for (int i = 0; i < leaf->primCount; ++i) {
 		int currIndex = bvh->primIndices[leaf->firstChildOrPrim + i];
-		void *object = instances[currIndex].object;
-		
-		struct lightRay copy = *ray;
-		transformPoint(&copy.start, &instances[currIndex].composite.Ainv);
-		transformVector(&copy.direction, &instances[currIndex].composite.Ainv);
-
-		if (instances[currIndex].intersectFn(object, &copy, isect)) {
+		if (instances[currIndex].intersectFn(&instances[currIndex], ray, isect)) {
 			isect->instIndex = currIndex;
 			found = true;
 		}

--- a/src/accelerators/bvh.h
+++ b/src/accelerators/bvh.h
@@ -15,8 +15,12 @@ struct hitRecord;
 struct mesh;
 struct poly;
 struct instance;
+struct boundingBox;
 
 struct bvh;
+
+/// Returns the bounding box of the root of the given BVH
+void getRootBoundingBox(const struct bvh *bvh, struct boundingBox *bbox);
 
 /// Builds a BVH for a given set of polygons
 /// @param polygons Array of polygons to process

--- a/src/datatypes/camera.c
+++ b/src/datatypes/camera.c
@@ -19,7 +19,7 @@
  */
 void transformCameraView(struct camera *cam, struct vector *direction) {
 	for (int i = 1; i < cam->transformCount; ++i) {
-		transformVector(direction, cam->transforms[i].A);
+		transformVector(direction, &cam->transforms[i].A);
 	}
 }
 
@@ -56,7 +56,7 @@ void initCamera(struct camera *cam) {
 void transformCameraIntoView(struct camera *cam) {
 	initCamera(cam);
 	//Compute transforms for position (place the camera in the scene)
-	transformPoint(&cam->pos, cam->transforms[0].A);
+	transformPoint(&cam->pos, &cam->transforms[0].A);
 	
 	//...and compute rotation transforms for camera orientation (point the camera)
 	transformCameraView(cam, &cam->left);

--- a/src/datatypes/instance.c
+++ b/src/datatypes/instance.c
@@ -35,7 +35,7 @@ static void getSphereBBoxAndCenter(const struct instance *instance, struct bound
 	transformPoint(center, &instance->composite.A);
 	bbox->min = vecWithPos(-sphere->radius, -sphere->radius, -sphere->radius);
 	bbox->max = vecWithPos( sphere->radius,  sphere->radius,  sphere->radius);
-	if (!isRotation(&instance->composite) || !isTranslate(&instance->composite))
+	if (!isRotation(&instance->composite) && !isTranslate(&instance->composite))
 		transformBBox(bbox, &instance->composite.A);
 	else {
 		bbox->min = vecAdd(bbox->min, *center);

--- a/src/datatypes/instance.c
+++ b/src/datatypes/instance.c
@@ -7,11 +7,59 @@
 //
 
 #include "../includes.h"
+#include "../accelerators/bvh.h"
+#include "../renderer/pathtrace.h"
 #include "vector.h"
-#include "../datatypes/transforms.h"
 #include "instance.h"
 #include "transforms.h"
+#include "bbox.h"
+#include "mesh.h"
+#include "sphere.h"
 #include "scene.h"
+
+static bool intersectSphere(void *object, const struct lightRay *ray, struct hitRecord *isect) {
+	if (rayIntersectsWithSphere(ray, (struct sphere*)object, isect)) {
+		isect->polygon = NULL;
+		isect->material = ((struct sphere*)object)->material;
+		return true;
+	}
+	return false;
+}
+
+static void getSphereBBoxAndCenter(void *object, struct boundingBox *bbox, struct vector *center) {
+	struct sphere *sphere = (struct sphere*)object;
+	bbox->min = vecWithPos(-sphere->radius, -sphere->radius, -sphere->radius);
+	bbox->max = vecWithPos( sphere->radius,  sphere->radius,  sphere->radius);
+	*center = vecZero();
+}
+
+struct instance newSphereInstance(struct sphere *sphere) {
+	return (struct instance) {
+		.object = sphere,
+		.composite = newTransform(),
+		.intersectFn = intersectSphere,
+		.getBBoxAndCenterFn = getSphereBBoxAndCenter
+	};
+}
+
+static bool intersectMesh(void *object, const struct lightRay *ray, struct hitRecord *isect) {
+	return traverseBottomLevelBvh((struct mesh*)object, ray, isect);
+}
+
+static void getMeshBBoxAndCenter(void *object, struct boundingBox *bbox, struct vector *center) {
+	struct mesh *mesh = (struct mesh*)object;
+	getRootBoundingBox(mesh->bvh, bbox);
+	*center = bboxCenter(bbox);
+}
+
+struct instance newMeshInstance(struct mesh *mesh) {
+	return (struct instance) {
+		.object = mesh,
+		.composite = newTransform(),
+		.intersectFn = intersectMesh,
+		.getBBoxAndCenterFn = getMeshBBoxAndCenter
+	};
+}
 
 void addInstanceToScene(struct world *scene, struct instance instance) {
 	if (scene->instanceCount == 0) {
@@ -20,13 +68,4 @@ void addInstanceToScene(struct world *scene, struct instance instance) {
 		scene->instances = realloc(scene->instances, (scene->instanceCount + 1) * sizeof(*scene->instances));
 	}
 	scene->instances[scene->instanceCount++] = instance;
-}
-
-void addSphereInstanceToScene(struct world *scene, struct instance instance) {
-	if (scene->sphereInstanceCount == 0) {
-		scene->sphereInstances = calloc(1, sizeof(*scene->sphereInstances));
-	} else {
-		scene->sphereInstances = realloc(scene->sphereInstances, (scene->sphereInstanceCount + 1) * sizeof(*scene->sphereInstances));
-	}
-	scene->sphereInstances[scene->sphereInstanceCount++] = instance;
 }

--- a/src/datatypes/instance.h
+++ b/src/datatypes/instance.h
@@ -21,8 +21,8 @@ struct mesh;
 
 struct instance {
 	struct transform composite;
-    bool (*intersectFn)(void*, const struct lightRay*, struct hitRecord*);
-    void (*getBBoxAndCenterFn)(void*, struct boundingBox*, struct vector*);
+	bool (*intersectFn)(void*, const struct lightRay*, struct hitRecord*);
+	void (*getBBoxAndCenterFn)(void*, struct boundingBox*, struct vector*);
 	void *object;
 };
 

--- a/src/datatypes/instance.h
+++ b/src/datatypes/instance.h
@@ -21,8 +21,8 @@ struct mesh;
 
 struct instance {
 	struct transform composite;
-	bool (*intersectFn)(void*, const struct lightRay*, struct hitRecord*);
-	void (*getBBoxAndCenterFn)(void*, struct boundingBox*, struct vector*);
+	bool (*intersectFn)(const struct instance*, const struct lightRay*, struct hitRecord*);
+	void (*getBBoxAndCenterFn)(const struct instance*, struct boundingBox*, struct vector*);
 	void *object;
 };
 

--- a/src/datatypes/instance.h
+++ b/src/datatypes/instance.h
@@ -8,15 +8,25 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include "transforms.h"
 
 struct world;
 struct matrix4x4;
+struct lightRay;
+struct hitRecord;
+
+struct sphere;
+struct mesh;
 
 struct instance {
 	struct transform composite;
+    bool (*intersectFn)(void*, const struct lightRay*, struct hitRecord*);
+    void (*getBBoxAndCenterFn)(void*, struct boundingBox*, struct vector*);
 	void *object;
 };
 
+struct instance newSphereInstance(struct sphere *sphere);
+struct instance newMeshInstance(struct mesh *mesh);
+
 void addInstanceToScene(struct world *scene, struct instance instance);
-void addSphereInstanceToScene(struct world *scene, struct instance instance);

--- a/src/datatypes/scene.c
+++ b/src/datatypes/scene.c
@@ -53,8 +53,8 @@ static void printSceneStats(struct world *scene, unsigned long long ms) {
 	logr(info, "Scene construction completed in ");
 	printSmartTime(ms);
 	unsigned polys = 0;
-	for (int i = 0; i < scene->instanceCount; ++i) {
-		polys += ((struct mesh*)scene->instances[i].object)->polyCount;
+	for (int i = 0; i < scene->meshCount; ++i) {
+		polys += scene->meshes[i].polyCount;
 	}
 	printf("\n");
 	logr(info, "Totals: %iV, %iN, %iT, %iP, %iS, %iM\n",

--- a/src/datatypes/scene.h
+++ b/src/datatypes/scene.h
@@ -33,9 +33,6 @@ struct world {
 	struct sphere *spheres;
 	int sphereCount;
 	
-	struct instance *sphereInstances;
-	int sphereInstanceCount;
-	
 	//Currently only one camera supported
 	struct camera *camera;
 	int cameraCount;

--- a/src/datatypes/sphere.c
+++ b/src/datatypes/sphere.c
@@ -37,11 +37,9 @@ bool intersect(const struct lightRay *ray, const struct sphere *sphere, float *t
 	float A = vecDot(ray->direction, ray->direction);
 	
 	//Distance between start of a lightRay and the sphere position
-	struct vector distance = vecSub(ray->start, vecZero());
+	float B = 2 * vecDot(ray->direction, ray->start);
 	
-	float B = 2 * vecDot(ray->direction, distance);
-	
-	float C = vecDot(distance, distance) - (sphere->radius * sphere->radius);
+	float C = vecDot(ray->start, ray->start) - (sphere->radius * sphere->radius);
 	
 	float trigDiscriminant = B * B - 4 * A * C;
 	
@@ -72,7 +70,7 @@ bool rayIntersectsWithSphere(const struct lightRay *ray, const struct sphere *sp
 		//Compute normal and store it to isect
 		struct vector scaled = vecScale(ray->direction, isect->distance);
 		struct vector hitPoint = vecAdd(ray->start, scaled);
-		isect->surfaceNormal = vecSub(hitPoint, vecZero());
+		isect->surfaceNormal = hitPoint;
 		isect->hitPoint = hitPoint;
 		isect->polygon = NULL;
 		return true;

--- a/src/datatypes/transforms.c
+++ b/src/datatypes/transforms.c
@@ -44,10 +44,11 @@ struct transform newTransform() {
 	return tf;
 }
 
-struct matrix4x4 fromParams(float t00, float t01, float t02, float t03,
-							float t10, float t11, float t12, float t13,
-							float t20, float t21, float t22, float t23,
-							float t30, float t31, float t32, float t33) {
+struct matrix4x4 matrixFromParams(
+	float t00, float t01, float t02, float t03,
+	float t10, float t11, float t12, float t13,
+	float t20, float t21, float t22, float t23,
+	float t30, float t31, float t32, float t33) {
 	struct matrix4x4 new = {{{0}}};
 	new.mtx[0][0] = t00; new.mtx[0][1] = t01; new.mtx[0][2] = t02; new.mtx[0][3] = t03;
 	new.mtx[1][0] = t10; new.mtx[1][1] = t11; new.mtx[1][2] = t12; new.mtx[1][3] = t13;
@@ -56,31 +57,54 @@ struct matrix4x4 fromParams(float t00, float t01, float t02, float t03,
 	return new;
 }
 
+struct matrix4x4 absoluteMatrix(const struct matrix4x4 *mtx) {
+	return (struct matrix4x4) {
+		.mtx = {
+			{ fabsf(mtx->mtx[0][0]), fabsf(mtx->mtx[0][1]), fabsf(mtx->mtx[0][2]), fabsf(mtx->mtx[0][3]) },
+			{ fabsf(mtx->mtx[1][0]), fabsf(mtx->mtx[1][1]), fabsf(mtx->mtx[1][2]), fabsf(mtx->mtx[1][3]) },
+			{ fabsf(mtx->mtx[2][0]), fabsf(mtx->mtx[2][1]), fabsf(mtx->mtx[2][2]), fabsf(mtx->mtx[2][3]) },
+			{ fabsf(mtx->mtx[3][0]), fabsf(mtx->mtx[3][1]), fabsf(mtx->mtx[3][2]), fabsf(mtx->mtx[3][3]) }
+		}
+	};
+}
+
 //http://tinyurl.com/hte35pq
 //TODO: Boolean switch to inverse, or just feed m4x4 directly
-void transformPoint(struct vector *vec, struct matrix4x4 mtx) {
+void transformPoint(struct vector *vec, const struct matrix4x4 *mtx) {
 	struct vector temp;
-	temp.x = (mtx.mtx[0][0] * vec->x) + (mtx.mtx[0][1] * vec->y) + (mtx.mtx[0][2] * vec->z) + mtx.mtx[0][3];
-	temp.y = (mtx.mtx[1][0] * vec->x) + (mtx.mtx[1][1] * vec->y) + (mtx.mtx[1][2] * vec->z) + mtx.mtx[1][3];
-	temp.z = (mtx.mtx[2][0] * vec->x) + (mtx.mtx[2][1] * vec->y) + (mtx.mtx[2][2] * vec->z) + mtx.mtx[2][3];
+	temp.x = (mtx->mtx[0][0] * vec->x) + (mtx->mtx[0][1] * vec->y) + (mtx->mtx[0][2] * vec->z) + mtx->mtx[0][3];
+	temp.y = (mtx->mtx[1][0] * vec->x) + (mtx->mtx[1][1] * vec->y) + (mtx->mtx[1][2] * vec->z) + mtx->mtx[1][3];
+	temp.z = (mtx->mtx[2][0] * vec->x) + (mtx->mtx[2][1] * vec->y) + (mtx->mtx[2][2] * vec->z) + mtx->mtx[2][3];
 	vec->x = temp.x;
 	vec->y = temp.y;
 	vec->z = temp.z;
 }
 
-void transformBBox(struct boundingBox *bbox, struct matrix4x4 *mtx) {
-	transformPoint(&bbox->max, *mtx);
-	transformPoint(&bbox->min, *mtx);
+void transformBBox(struct boundingBox *bbox, const struct matrix4x4 *mtx) {
+	struct matrix4x4 abs = absoluteMatrix(mtx);
+	struct vector center = vecScale(vecAdd(bbox->min, bbox->max), 0.5f);
+	struct vector halfExtents = vecScale(vecSub(bbox->max, bbox->min), 0.5f);
+	transformVector(&halfExtents, &abs);
+	transformPoint(&center, &abs);
+	bbox->min = vecSub(center, halfExtents);
+	bbox->max = vecAdd(center, halfExtents);
 }
 
-void transformVector(struct vector *vec, struct matrix4x4 mtx) {
+void transformVector(struct vector *vec, const struct matrix4x4 *mtx) {
 	struct vector temp;
-	temp.x = (mtx.mtx[0][0] * vec->x) + (mtx.mtx[0][1] * vec->y) + (mtx.mtx[0][2] * vec->z);
-	temp.y = (mtx.mtx[1][0] * vec->x) + (mtx.mtx[1][1] * vec->y) + (mtx.mtx[1][2] * vec->z);
-	temp.z = (mtx.mtx[2][0] * vec->x) + (mtx.mtx[2][1] * vec->y) + (mtx.mtx[2][2] * vec->z);
+	temp.x = (mtx->mtx[0][0] * vec->x) + (mtx->mtx[0][1] * vec->y) + (mtx->mtx[0][2] * vec->z);
+	temp.y = (mtx->mtx[1][0] * vec->x) + (mtx->mtx[1][1] * vec->y) + (mtx->mtx[1][2] * vec->z);
+	temp.z = (mtx->mtx[2][0] * vec->x) + (mtx->mtx[2][1] * vec->y) + (mtx->mtx[2][2] * vec->z);
 	vec->x = temp.x;
 	vec->y = temp.y;
 	vec->z = temp.z;
+}
+
+void transformVectorWithTranspose(struct vector *vec, const struct matrix4x4 *mtx) {
+	// Doing this here gives an opportunity for the compiler
+	// to inline the calls to transformVector() and transposeMatrix()
+	struct matrix4x4 t = transposeMatrix(mtx);
+	transformVector(vec, &t);
 }
 
 struct transform newTransformRotateX(float rads) {
@@ -94,8 +118,7 @@ struct transform newTransformRotateX(float rads) {
 	transform.A.mtx[2][1] = sinRads;
 	transform.A.mtx[2][2] = cosRads;
 	transform.A.mtx[3][3] = 1.0f;
-	transform.Ainv = inverse(transform.A);
-	transform.AinvT = transpose(transform.Ainv);
+	transform.Ainv = inverseMatrix(&transform.A);
 	return transform;
 }
 
@@ -110,8 +133,7 @@ struct transform newTransformRotateY(float rads) {
 	transform.A.mtx[2][0] = -sinRads;
 	transform.A.mtx[2][2] = cosRads;
 	transform.A.mtx[3][3] = 1.0f;
-	transform.Ainv = inverse(transform.A);
-	transform.AinvT = transpose(transform.Ainv);
+	transform.Ainv = inverseMatrix(&transform.A);
 	return transform;
 }
 
@@ -126,8 +148,7 @@ struct transform newTransformRotateZ(float rads) {
 	transform.A.mtx[1][1] = cosRads;
 	transform.A.mtx[2][2] = 1.0f;
 	transform.A.mtx[3][3] = 1.0f;
-	transform.Ainv = inverse(transform.A);
-	transform.AinvT = transpose(transform.Ainv);
+	transform.Ainv = inverseMatrix(&transform.A);
 	return transform;
 }
 
@@ -141,8 +162,7 @@ struct transform newTransformTranslate(float x, float y, float z) {
 	transform.A.mtx[0][3] = x;
 	transform.A.mtx[1][3] = y;
 	transform.A.mtx[2][3] = z;
-	transform.Ainv = inverse(transform.A);
-	transform.AinvT = transpose(transform.Ainv);
+	transform.Ainv = inverseMatrix(&transform.A);
 	return transform;
 }
 
@@ -153,8 +173,7 @@ struct transform newTransformScale(float x, float y, float z) {
 	transform.A.mtx[1][1] = y;
 	transform.A.mtx[2][2] = z;
 	transform.A.mtx[3][3] = 1.0f;
-	transform.Ainv = inverse(transform.A);
-	transform.AinvT = transpose(transform.Ainv);
+	transform.Ainv = inverseMatrix(&transform.A);
 	return transform;
 }
 
@@ -165,8 +184,7 @@ struct transform newTransformScaleUniform(float scale) {
 	transform.A.mtx[1][1] = scale;
 	transform.A.mtx[2][2] = scale;
 	transform.A.mtx[3][3] = 1.0f;
-	transform.Ainv = inverse(transform.A);
-	transform.AinvT = transpose(transform.Ainv);
+	transform.Ainv = inverseMatrix(&transform.A);
 	return transform;
 }
 
@@ -229,16 +247,16 @@ static void findAdjoint(const float A[4][4], float adjoint[4][4]) {
 	}
 }
 
-struct matrix4x4 inverse(const struct matrix4x4 mtx) {
+struct matrix4x4 inverseMatrix(const struct matrix4x4 *mtx) {
 	struct matrix4x4 inverse = {{{0}}};
 	
-	float det = findDeterminant4x4(mtx.mtx);
+	float det = findDeterminant4x4(mtx->mtx);
 	if (det <= 0.0f) {
 		logr(error, "No inverse for given transform!\n");
 	}
 	
 	float adjoint[4][4];
-	findAdjoint(mtx.mtx, adjoint);
+	findAdjoint(mtx->mtx, adjoint);
 	
 	for (int i = 0; i < 4; ++i) {
 		for (int j = 0; j < 4; ++j) {
@@ -248,40 +266,39 @@ struct matrix4x4 inverse(const struct matrix4x4 mtx) {
 	
 	//Not sure why I need to transpose here, but doing so
 	//gives correct results
-	return transpose(inverse);
+	return transposeMatrix(&inverse);
 }
 
-struct matrix4x4 transpose(struct matrix4x4 tf) {
-	return fromParams(
-					tf.mtx[0][0], tf.mtx[1][0], tf.mtx[2][0], tf.mtx[3][0],
-					tf.mtx[0][1], tf.mtx[1][1], tf.mtx[2][1], tf.mtx[3][1],
-					tf.mtx[0][2], tf.mtx[1][2], tf.mtx[2][2], tf.mtx[3][2],
-					tf.mtx[0][3], tf.mtx[1][3], tf.mtx[2][3], tf.mtx[3][3]
-					);
+struct matrix4x4 transposeMatrix(const struct matrix4x4 *tf) {
+	return matrixFromParams(
+		tf->mtx[0][0], tf->mtx[1][0], tf->mtx[2][0], tf->mtx[3][0],
+		tf->mtx[0][1], tf->mtx[1][1], tf->mtx[2][1], tf->mtx[3][1],
+		tf->mtx[0][2], tf->mtx[1][2], tf->mtx[2][2], tf->mtx[3][2],
+		tf->mtx[0][3], tf->mtx[1][3], tf->mtx[2][3], tf->mtx[3][3]
+	);
 }
 
-struct matrix4x4 multiply(struct matrix4x4 A, struct matrix4x4 B) {
-	return fromParams(
-					A.mtx[0][0] * B.mtx[0][0] + A.mtx[0][1] * B.mtx[1][0] + A.mtx[0][2] * B.mtx[2][0] + A.mtx[0][3] * B.mtx[3][0],
-					A.mtx[0][0] * B.mtx[0][1] + A.mtx[0][1] * B.mtx[1][1] + A.mtx[0][2] * B.mtx[2][1] + A.mtx[0][3] * B.mtx[3][1],
-					A.mtx[0][0] * B.mtx[0][2] + A.mtx[0][1] * B.mtx[1][2] + A.mtx[0][2] * B.mtx[2][2] + A.mtx[0][3] * B.mtx[3][2],
-					A.mtx[0][0] * B.mtx[0][3] + A.mtx[0][1] * B.mtx[1][3] + A.mtx[0][2] * B.mtx[2][3] + A.mtx[0][3] * B.mtx[3][3],
-					
-					A.mtx[1][0] * B.mtx[0][0] + A.mtx[1][1] * B.mtx[1][0] + A.mtx[1][2] * B.mtx[2][0] + A.mtx[1][3] * B.mtx[3][0],
-					A.mtx[1][0] * B.mtx[0][1] + A.mtx[1][1] * B.mtx[1][1] + A.mtx[1][2] * B.mtx[2][1] + A.mtx[1][3] * B.mtx[3][1],
-					A.mtx[1][0] * B.mtx[0][2] + A.mtx[1][1] * B.mtx[1][2] + A.mtx[1][2] * B.mtx[2][2] + A.mtx[1][3] * B.mtx[3][2],
-					A.mtx[1][0] * B.mtx[0][3] + A.mtx[1][1] * B.mtx[1][3] + A.mtx[1][2] * B.mtx[2][3] + A.mtx[1][3] * B.mtx[3][3],
-					
-					A.mtx[2][0] * B.mtx[0][0] + A.mtx[2][1] * B.mtx[1][0] + A.mtx[2][2] * B.mtx[2][0] + A.mtx[2][3] * B.mtx[3][0],
-					A.mtx[2][0] * B.mtx[0][1] + A.mtx[2][1] * B.mtx[1][1] + A.mtx[2][2] * B.mtx[2][1] + A.mtx[2][3] * B.mtx[3][1],
-					A.mtx[2][0] * B.mtx[0][2] + A.mtx[2][1] * B.mtx[1][2] + A.mtx[2][2] * B.mtx[2][2] + A.mtx[2][3] * B.mtx[3][2],
-					A.mtx[2][0] * B.mtx[0][3] + A.mtx[2][1] * B.mtx[1][3] + A.mtx[2][2] * B.mtx[2][3] + A.mtx[2][3] * B.mtx[3][3],
-					
-					A.mtx[3][0] * B.mtx[0][0] + A.mtx[3][1] * B.mtx[1][0] + A.mtx[3][2] * B.mtx[2][0] + A.mtx[3][3] * B.mtx[3][0],
-					A.mtx[3][0] * B.mtx[0][1] + A.mtx[3][1] * B.mtx[1][1] + A.mtx[3][2] * B.mtx[2][1] + A.mtx[3][3] * B.mtx[3][1],
-					A.mtx[3][0] * B.mtx[0][2] + A.mtx[3][1] * B.mtx[1][2] + A.mtx[3][2] * B.mtx[2][2] + A.mtx[3][3] * B.mtx[3][2],
-					A.mtx[3][0] * B.mtx[0][3] + A.mtx[3][1] * B.mtx[1][3] + A.mtx[3][2] * B.mtx[2][3] + A.mtx[3][3] * B.mtx[3][3]
-			);
+struct matrix4x4 multiplyMatrices(const struct matrix4x4 *A, const struct matrix4x4 *B) {
+	return matrixFromParams(
+		A->mtx[0][0] * B->mtx[0][0] + A->mtx[0][1] * B->mtx[1][0] + A->mtx[0][2] * B->mtx[2][0] + A->mtx[0][3] * B->mtx[3][0],
+		A->mtx[0][0] * B->mtx[0][1] + A->mtx[0][1] * B->mtx[1][1] + A->mtx[0][2] * B->mtx[2][1] + A->mtx[0][3] * B->mtx[3][1],
+		A->mtx[0][0] * B->mtx[0][2] + A->mtx[0][1] * B->mtx[1][2] + A->mtx[0][2] * B->mtx[2][2] + A->mtx[0][3] * B->mtx[3][2],
+		A->mtx[0][0] * B->mtx[0][3] + A->mtx[0][1] * B->mtx[1][3] + A->mtx[0][2] * B->mtx[2][3] + A->mtx[0][3] * B->mtx[3][3],
+
+		A->mtx[1][0] * B->mtx[0][0] + A->mtx[1][1] * B->mtx[1][0] + A->mtx[1][2] * B->mtx[2][0] + A->mtx[1][3] * B->mtx[3][0],
+		A->mtx[1][0] * B->mtx[0][1] + A->mtx[1][1] * B->mtx[1][1] + A->mtx[1][2] * B->mtx[2][1] + A->mtx[1][3] * B->mtx[3][1],
+		A->mtx[1][0] * B->mtx[0][2] + A->mtx[1][1] * B->mtx[1][2] + A->mtx[1][2] * B->mtx[2][2] + A->mtx[1][3] * B->mtx[3][2],
+		A->mtx[1][0] * B->mtx[0][3] + A->mtx[1][1] * B->mtx[1][3] + A->mtx[1][2] * B->mtx[2][3] + A->mtx[1][3] * B->mtx[3][3],
+
+		A->mtx[2][0] * B->mtx[0][0] + A->mtx[2][1] * B->mtx[1][0] + A->mtx[2][2] * B->mtx[2][0] + A->mtx[2][3] * B->mtx[3][0],
+		A->mtx[2][0] * B->mtx[0][1] + A->mtx[2][1] * B->mtx[1][1] + A->mtx[2][2] * B->mtx[2][1] + A->mtx[2][3] * B->mtx[3][1],
+		A->mtx[2][0] * B->mtx[0][2] + A->mtx[2][1] * B->mtx[1][2] + A->mtx[2][2] * B->mtx[2][2] + A->mtx[2][3] * B->mtx[3][2],
+		A->mtx[2][0] * B->mtx[0][3] + A->mtx[2][1] * B->mtx[1][3] + A->mtx[2][2] * B->mtx[2][3] + A->mtx[2][3] * B->mtx[3][3],
+
+		A->mtx[3][0] * B->mtx[0][0] + A->mtx[3][1] * B->mtx[1][0] + A->mtx[3][2] * B->mtx[2][0] + A->mtx[3][3] * B->mtx[3][0],
+		A->mtx[3][0] * B->mtx[0][1] + A->mtx[3][1] * B->mtx[1][1] + A->mtx[3][2] * B->mtx[2][1] + A->mtx[3][3] * B->mtx[3][1],
+		A->mtx[3][0] * B->mtx[0][2] + A->mtx[3][1] * B->mtx[1][2] + A->mtx[3][2] * B->mtx[2][2] + A->mtx[3][3] * B->mtx[3][2],
+		A->mtx[3][0] * B->mtx[0][3] + A->mtx[3][1] * B->mtx[1][3] + A->mtx[3][2] * B->mtx[2][3] + A->mtx[3][3] * B->mtx[3][3]);
 }
 
 static char *transformTypeString(enum transformType type) {
@@ -311,23 +328,23 @@ static char *transformTypeString(enum transformType type) {
 	}
 }
 
-bool isRotation(struct transform t) {
-	return (t.type == transformTypeXRotate) || (t.type == transformTypeYRotate) || (t.type == transformTypeZRotate);
+bool isRotation(const struct transform *t) {
+	return (t->type == transformTypeXRotate) || (t->type == transformTypeYRotate) || (t->type == transformTypeZRotate);
 }
 
-bool isScale(struct transform t) {
-	return t.type == transformTypeScale;
+bool isScale(const struct transform *t) {
+	return t->type == transformTypeScale;
 }
 
-bool isTranslate(struct transform t) {
-	return t.type == transformTypeTranslate;
+bool isTranslate(const struct transform *t) {
+	return t->type == transformTypeTranslate;
 }
 
-static void printMatrix(struct matrix4x4 mtx) {
+static void printMatrix(const struct matrix4x4 *mtx) {
 	printf("\n");
 	for (int i = 0; i < 4; ++i) {
 		for (int j = 0; j < 4; ++j) {
-			printf("mtx.mtx[%i][%i]=%s%f ",i,j, mtx.mtx[i][j] < 0 ? "" : " " ,mtx.mtx[i][j]);
+			printf("mtx.mtx[%i][%i]=%s%f ",i,j, mtx->mtx[i][j] < 0 ? "" : " " ,mtx->mtx[i][j]);
 		}
 		printf("\n");
 	}
@@ -338,13 +355,14 @@ static void printMatrix(struct matrix4x4 mtx) {
 	printf("%s", transformTypeString(tf.type));
 	printMatrix(tf.A);
 	printMatrix(tf.Ainv);
-}*/
+}
+*/
 
-bool areEqual(struct matrix4x4 A, struct matrix4x4 B) {
+bool areMatricesEqual(const struct matrix4x4 *A, const struct matrix4x4 *B) {
 	bool matches = true;
 	for (unsigned j = 0; j < 4; ++j) {
 		for (unsigned i = 0; i < 4; ++i) {
-			if (A.mtx[i][j] != B.mtx[i][j]) matches = false;
+			if (A->mtx[i][j] != B->mtx[i][j]) matches = false;
 		}
 	}
 	return matches;

--- a/src/datatypes/transforms.c
+++ b/src/datatypes/transforms.c
@@ -12,6 +12,7 @@
 #include "../utils/logging.h"
 #include "vector.h"
 #include "bbox.h"
+#include "lightRay.h"
 
 //For ease of use
 float toRadians(float degrees) {
@@ -60,10 +61,12 @@ struct matrix4x4 matrixFromParams(
 struct matrix4x4 absoluteMatrix(const struct matrix4x4 *mtx) {
 	return (struct matrix4x4) {
 		.mtx = {
-			{ fabsf(mtx->mtx[0][0]), fabsf(mtx->mtx[0][1]), fabsf(mtx->mtx[0][2]), fabsf(mtx->mtx[0][3]) },
-			{ fabsf(mtx->mtx[1][0]), fabsf(mtx->mtx[1][1]), fabsf(mtx->mtx[1][2]), fabsf(mtx->mtx[1][3]) },
-			{ fabsf(mtx->mtx[2][0]), fabsf(mtx->mtx[2][1]), fabsf(mtx->mtx[2][2]), fabsf(mtx->mtx[2][3]) },
-			{ fabsf(mtx->mtx[3][0]), fabsf(mtx->mtx[3][1]), fabsf(mtx->mtx[3][2]), fabsf(mtx->mtx[3][3]) }
+			// The last column is the translation, and should be kept intact
+			{ fabsf(mtx->mtx[0][0]), fabsf(mtx->mtx[0][1]), fabsf(mtx->mtx[0][2]), mtx->mtx[0][3] },
+			{ fabsf(mtx->mtx[1][0]), fabsf(mtx->mtx[1][1]), fabsf(mtx->mtx[1][2]), mtx->mtx[1][3] },
+			{ fabsf(mtx->mtx[2][0]), fabsf(mtx->mtx[2][1]), fabsf(mtx->mtx[2][2]), mtx->mtx[2][3] },
+			// These coefficients are not used anyway
+			{ mtx->mtx[3][0], mtx->mtx[3][1], mtx->mtx[3][2], mtx->mtx[3][3] }
 		}
 	};
 }
@@ -105,6 +108,11 @@ void transformVectorWithTranspose(struct vector *vec, const struct matrix4x4 *mt
 	// to inline the calls to transformVector() and transposeMatrix()
 	struct matrix4x4 t = transposeMatrix(mtx);
 	transformVector(vec, &t);
+}
+
+void transformRay(struct lightRay *ray, const struct matrix4x4 *mtx) {
+	transformPoint(&ray->start, mtx);
+	transformVector(&ray->direction, mtx);
 }
 
 struct transform newTransformRotateX(float rads) {

--- a/src/datatypes/transforms.h
+++ b/src/datatypes/transforms.h
@@ -45,6 +45,7 @@ struct transform {
 struct material;
 struct vector;
 struct boundingBox;
+struct lightRay;
 
 float toRadians(float degrees);
 float fromRadians(float radians);
@@ -67,6 +68,7 @@ void transformPoint(struct vector *vec, const struct matrix4x4 *mtx);
 void transformVector(struct vector *vec, const struct matrix4x4 *mtx);
 void transformVectorWithTranspose(struct vector *vec, const struct matrix4x4 *mtx);
 void transformBBox(struct boundingBox *bbox, const struct matrix4x4 *mtx);
+void transformRay(struct lightRay *ray, const struct matrix4x4 *mtx);
 
 bool isRotation(const struct transform *t);
 bool isScale(const struct transform *t);

--- a/src/datatypes/transforms.h
+++ b/src/datatypes/transforms.h
@@ -40,7 +40,6 @@ struct transform {
 	enum transformType type;
 	struct matrix4x4 A;
 	struct matrix4x4 Ainv;
-	struct matrix4x4 AinvT;
 };
 
 struct material;
@@ -59,14 +58,18 @@ struct transform newTransformRotateY(float radians);
 struct transform newTransformRotateZ(float radians);
 struct transform newTransform(void);
 
-struct matrix4x4 inverse(struct matrix4x4 mtx);
-struct matrix4x4 transpose(struct matrix4x4 tf);
-struct matrix4x4 multiply(struct matrix4x4 A, struct matrix4x4 B); //FIXME: Maybe don't expose this.
+struct matrix4x4 inverseMatrix(const struct matrix4x4 *mtx);
+struct matrix4x4 transposeMatrix(const struct matrix4x4 *tf);
+struct matrix4x4 multiplyMatrices(const struct matrix4x4 *A, const struct matrix4x4 *B); //FIXME: Maybe don't expose this.
+struct matrix4x4 absoluteMatrix(const struct matrix4x4 *mtx);
 
-void transformPoint(struct vector *vec, struct matrix4x4 mtx);
-void transformVector(struct vector *vec, struct matrix4x4 mtx);
-void transformBBox(struct boundingBox *bbox, struct matrix4x4 *mtx);
+void transformPoint(struct vector *vec, const struct matrix4x4 *mtx);
+void transformVector(struct vector *vec, const struct matrix4x4 *mtx);
+void transformVectorWithTranspose(struct vector *vec, const struct matrix4x4 *mtx);
+void transformBBox(struct boundingBox *bbox, const struct matrix4x4 *mtx);
 
-bool isRotation(struct transform t);
-bool isScale(struct transform t);
-bool isTranslate(struct transform t);
+bool isRotation(const struct transform *t);
+bool isScale(const struct transform *t);
+bool isTranslate(const struct transform *t);
+
+bool areMatricesEqual(const struct matrix4x4 *A, const struct matrix4x4 *B);

--- a/src/includes.h
+++ b/src/includes.h
@@ -16,7 +16,7 @@
 #define CRAY_MESH_FILENAME_LENGTH 500
 
 //#define DBG_NORMALS //Normal debugging mode
-#define LINEAR      //Skip top-level BVH traversal
+//#define LINEAR      //Skip top-level BVH traversal
 
 //Some macros
 #define min(a,b) (((a) < (b)) ? (a) : (b))

--- a/src/renderer/pathtrace.h
+++ b/src/renderer/pathtrace.h
@@ -18,29 +18,19 @@ struct world;
 //FIXME: These datatypes should be hidden inside the implementation!
 
 /**
- Ray intersection type enum
- */
-enum currentType {
-	hitTypeNone,
-	hitTypePolygon,
-	hitTypeSphere
-};
-
-/**
  Shading/intersection information, used to perform shading and rendering logic.
  @note uv, mtlIndex and polyIndex are only set if the ray hits a polygon (mesh)
  @todo Consider moving start, end materials to lightRay instead
  */
 struct hitRecord {
 	struct lightRay incident;		//Light ray that encountered this intersection
-	struct material end;			//Material of the intersected object
+	struct material material;	    //Material of the intersected object
 	struct vector hitPoint;			//Hit point vector in 3D space
 	struct vector surfaceNormal;	//Surface normal at that point of intersection
 	struct coord uv;				//UV barycentric coordinates for intersection point
-	enum currentType type;			//Type of object ray intersected with
 	float distance;					//Distance to intersection point
 	struct poly *polygon;			//ptr to polygon that was encountered
-	unsigned instIndex: 16;
+	int instIndex;                  //Instance index, negative if no intersection
 };
 
 

--- a/tests/test_transforms.h
+++ b/tests/test_transforms.h
@@ -12,36 +12,32 @@
 //FIXME: This is a bit of a hack. Maybe find a better way?
 float findDeterminant(float A[4][4], int n);
 float findDeterminant4x4(float A[4][4]);
-struct matrix4x4 fromParams(float t00, float t01, float t02, float t03,
-							float t10, float t11, float t12, float t13,
-							float t20, float t21, float t22, float t23,
-							float t30, float t31, float t32, float t33);
-struct matrix4x4 identityMatrix(void);
-struct matrix4x4 multiply(struct matrix4x4 A, struct matrix4x4 B);
-bool areEqual(struct matrix4x4 A, struct matrix4x4 B);
+struct matrix4x4 matrixFromParams(
+	float t00, float t01, float t02, float t03,
+	float t10, float t11, float t12, float t13,
+	float t20, float t21, float t22, float t23,
+	float t30, float t31, float t32, float t33);
+struct matrix4x4 identityMatrix();
 
 bool transform_multiply() {
 	bool pass = true;
-	struct matrix4x4 A = fromParams(
-									5, 7, 9, 10,
-									2, 3, 3, 8,
-									8, 10, 2, 3,
-									3, 3, 4, 8
-									);
-	struct matrix4x4 B = fromParams(
-									3, 10, 12, 18,
-									12, 1, 4, 9,
-									9, 10, 12, 2,
-									3, 12, 4, 10
-									);
-	struct matrix4x4 AB = multiply(A, B);
-	struct matrix4x4 expectedResult = fromParams(
-												 210, 267, 236, 271,
-												 93, 149, 104, 149,
-												 171, 146, 172, 268,
-												 105, 169, 128, 169
-												 );
-	test_assert(areEqual(AB, expectedResult));
+	struct matrix4x4 A = matrixFromParams(
+		5, 7, 9, 10,
+		2, 3, 3, 8,
+		8, 10, 2, 3,
+		3, 3, 4, 8);
+	struct matrix4x4 B = matrixFromParams(
+		3, 10, 12, 18,
+		12, 1, 4, 9,
+		9, 10, 12, 2,
+		3, 12, 4, 10);
+	struct matrix4x4 AB = multiplyMatrices(&A, &B);
+	struct matrix4x4 expectedResult = matrixFromParams(
+		210, 267, 236, 271,
+		93, 149, 104, 149,
+		171, 146, 172, 268,
+		105, 169, 128, 169);
+	test_assert(areMatricesEqual(&AB, &expectedResult));
 	return pass;
 }
 
@@ -49,43 +45,46 @@ bool transform_transpose() {
 	bool pass = true;
 	
 	// Identity matrices don't care about transpose
-	test_assert(areEqual(identityMatrix(), transpose(identityMatrix())));
+	struct matrix4x4 id = identityMatrix();
+	struct matrix4x4 tid = transposeMatrix(&id);
+	test_assert(areMatricesEqual(&id, &tid));
 	
-	struct matrix4x4 transposable = fromParams(
-											0, 0, 0, 1,
-											0, 0, 1, 0,
-											0, 2, 0, 0,
-											2, 0, 0, 0
-											);
+	struct matrix4x4 transposable = matrixFromParams(
+		0, 0, 0, 1,
+		0, 0, 1, 0,
+		0, 2, 0, 0,
+		2, 0, 0, 0);
 	
-	struct matrix4x4 expected = fromParams(
-										0, 0, 0, 2,
-										0, 0, 2, 0,
-										0, 1, 0, 0,
-										1, 0, 0, 0
-										);
+	struct matrix4x4 expected = matrixFromParams(
+		0, 0, 0, 2,
+		0, 0, 2, 0,
+		0, 1, 0, 0,
+		1, 0, 0, 0);
+	struct matrix4x4 transposed = transposeMatrix(&transposable);
 	
-	test_assert(areEqual(transpose(transposable), expected));
+	test_assert(areMatricesEqual(&transposed, &expected));
 	
 	return pass;
 }
 
 bool transform_determinant() {
 	bool pass = true;
-	struct matrix4x4 mtx = fromParams(1, 2, 0, 0,
-									  1, 1, 3, 0,
-									  0, 2, -2, 0,
-									  0, 0, 3, 1);
+	struct matrix4x4 mtx = matrixFromParams(
+		1, 2, 0, 0,
+		1, 1, 3, 0,
+		0, 2, -2, 0,
+		0, 0, 3, 1);
 	test_assert(findDeterminant(mtx.mtx, 4) == -4.0f);
 	return pass;
 }
 
 bool transform_determinant4x4() {
 	bool pass = true;
-	struct matrix4x4 mtx = fromParams(1, 2, 0, 0,
-									  1, 1, 3, 0,
-									  0, 2, -2, 0,
-									  0, 0, 3, 1);
+	struct matrix4x4 mtx = matrixFromParams(
+		1, 2, 0, 0,
+		1, 1, 3, 0,
+		0, 2, -2, 0,
+		0, 0, 3, 1);
 	test_assert(findDeterminant4x4(mtx.mtx) == -4.0f);
 	return pass;
 }


### PR DESCRIPTION
This also fixes naming schemes for exported functions to avoid conflicts (e.g. `inverse` -> `inverseMatrix`), and uses a consistent argument passing convention for matrix-related functions, enforcing the use of pointers when taking matrix arguments (which should be better in terms of performance for functions that cannot be inlined, because it avoids a copy).
Now, spheres and meshes alike can be placed in the BVH.