### PR TITLE
Implement a chained hash table

### DIFF
--- a/src/utils/hashtable.c
+++ b/src/utils/hashtable.c
@@ -10,161 +10,268 @@
 #include "hashtable.h"
 
 #include <inttypes.h>
+#include <assert.h>
 #include "logging.h"
 #include "../datatypes/vector.h"
 #include "assert.h"
 #include "fileio.h"
 #include "string.h"
 
-// Fowler-Noll-Vo hash function
-uint64_t hashDataToU64(const char *data, size_t size) {
-	static const uint64_t FNVOffsetBasis = 14695981039346656037U;
-	static const uint64_t FNVPrime = 1099511628211;
-	uint64_t hash = FNVOffsetBasis;
-	for (size_t i = 0; i < size; ++i) {
-		char dataByte = data[i];
-		hash = (~0xFF & hash) | (0xFF & (hash ^ dataByte));
-		hash = hash * FNVPrime;
-	}
-	return hash;
+#define FNV_OFFSET UINT32_C(0x811C9DC5) // Initial value for an empty hash
+#define FNV_PRIME  UINT32_C(0x01000193)
+
+// Default hash map capacity. Must be a power of two.
+#define DEFAULT_CAPACITY 8
+// Maximum load factor (average number of elements per bucket) in percent.
+#define MAX_LOAD_FACTOR_PERCENT 80
+
+uint32_t hashInit(void) {
+	return FNV_OFFSET;
 }
 
-struct bucket *getBucketPtr(struct hashtable *e, const char *key) {
-	struct bucket *result;
-	uint64_t index = hashDataToU64(key, strlen(key)) % e->size;
-	for (; index < e->size; ++index) {
-		result = &e->data[index];
-		if (result->used && result->key != NULL) {
-			if (!strcmp(key, result->key)) return result;
-		} else {
-			return result;
-		}
+uint32_t hashCombine(uint32_t h, uint8_t u) {
+	return (h ^ u) * FNV_PRIME;
+}
+
+uint32_t hashBytes(uint32_t h, const void* bytes, size_t size) {
+	for (size_t i = 0; i < size; ++i)
+		h = hashCombine(h, ((uint8_t*)bytes)[i]);
+	return h;
+}
+
+uint32_t hashString(uint32_t h, const char* str) {
+	for (size_t i = 0; str[i]; ++i)
+		h = hashCombine(h, str[i]);
+	return h;
+}
+
+static inline bool isPowerOfTwo(size_t i) {
+	return (i & (i - 1)) == 0;
+}
+
+struct hashtable* newHashtable(bool (*compare)(const void*, const void*)) {
+	struct hashtable *hashtable = malloc(sizeof(struct hashtable));
+	hashtable->bucketCount = DEFAULT_CAPACITY;
+	hashtable->buckets = calloc(DEFAULT_CAPACITY, sizeof(struct bucket*));
+	hashtable->elemCount = 0;
+	hashtable->compare = compare;
+	return hashtable;
+}
+
+static inline size_t hashToIndex(struct hashtable *hashtable, uint32_t hash) {
+	assert(isPowerOfTwo(hashtable->bucketCount));
+	return hash & (hashtable->bucketCount - 1);
+}
+
+void* findInHashtable(struct hashtable *hashtable, const void* element, uint32_t hash) {
+	struct bucket *bucket = hashtable->buckets[hashToIndex(hashtable, hash)];
+	while (bucket) {
+		if (bucket->hash == hash && hashtable->compare(&element, &bucket->data))
+			return &bucket->data;
+		bucket = bucket->next;
 	}
 	return NULL;
 }
 
-bool exists(struct hashtable *e, const char *key) {
-	return getBucketPtr(e, key)->used;
+static inline bool needsRehash(struct hashtable *hashtable) {
+	return hashtable->elemCount * MAX_LOAD_FACTOR_PERCENT / hashtable->bucketCount > 100;
 }
 
-void setVector(struct hashtable *e, const char *key, struct vector value) {
-	struct bucket *ptr = getBucketPtr(e, key);
-	if (!ptr->used)
-		ptr->value = malloc(sizeof(struct vector));
-	ptr->used = true;
-	*(struct vector*)ptr->value = value;
-}
-
-struct vector getVector(struct hashtable *e, const char *key) {
-	struct bucket *ptr = getBucketPtr(e, key);
-	return ptr->used ? *(struct vector*)ptr->value : (struct vector){0.0f, 0.0f, 0.0f};
-}
-
-void setFloat(struct hashtable *e, const char *key, float value) {
-	struct bucket *ptr = getBucketPtr(e, key);
-	if (!ptr->used)
-		ptr->value = malloc(sizeof(float));
-	ptr->used = true;
-	*(float*)ptr->value = value;
-}
-
-float getFloat(struct hashtable *e, const char *key) {
-	return *(float*)getBucketPtr(e, key)->value;
-}
-
-void setTag(struct hashtable *e, const char *key) {
-	struct bucket *ptr = getBucketPtr(e, key);
-	ptr->used = true;
-}
-
-void setString(struct hashtable *e, const char *key, const char *value) {
-	struct bucket *ptr = getBucketPtr(e, key);
-	if (!ptr->used) {
-		ptr->value = stringCopy(value);
-	}
-	ptr->used = true;
-}
-
-char *getString(struct hashtable *e, const char *key) {
-	struct bucket *ptr = getBucketPtr(e, key);
-	return ptr->used ? (char*)ptr->value : NULL;
-}
-
-void setInt(struct hashtable *e, const char *key, int value) {
-	struct bucket *ptr = getBucketPtr(e, key);
-	if (ptr->used) free(ptr->value);
-	ptr->value = malloc(sizeof(int));
-	ptr->used = true;
-	*(int*)ptr->value = value;
-}
-
-int getInt(struct hashtable *e, const char *key) {
-	return *(int*)getBucketPtr(e, key)->value;
-}
-
-static const uint64_t defaultTableSize = 2048;
-struct hashtable *newTable() {
-	struct hashtable *table = malloc(sizeof(*table));
-	table->size = defaultTableSize;
-	table->data = malloc(sizeof(*table->data) * defaultTableSize);
-	for (uint64_t i = 0; i < defaultTableSize; ++i) {
-		table->data[i].used = false;
-		table->data[i].value = NULL;
-		table->data[i].key = NULL;
-	}
-	return table;
-}
-
-void freeTable(struct hashtable *table) {
-	if (!table) return;
-	
-	for (uint64_t i = 0; i < defaultTableSize; ++i) {
-		if (table->data[i].used) {
-			free(table->data[i].value);
-			free(table->data[i].key);
+static inline void rehash(struct hashtable *hashtable) {
+	size_t newBucketCount = 2 * hashtable->bucketCount;
+	struct bucket **newBuckets = calloc(newBucketCount, sizeof(struct bucket*));
+	struct hashtable newHashtable = {
+		.bucketCount = newBucketCount,
+		.buckets = newBuckets
+	};
+	for (size_t i = 0, n = hashtable->bucketCount; i < n; ++i) {
+		struct bucket *bucket = hashtable->buckets[i];
+		while (bucket) {
+			struct bucket *next = bucket->next;
+			struct bucket **newBucket = &newBuckets[hashToIndex(&newHashtable, bucket->hash)];
+			bucket->next = *newBucket;
+			*newBucket = bucket;
+			bucket = next;
 		}
 	}
-	free(table->data);
-	free(table);
+	hashtable->buckets = newBuckets;
+	hashtable->bucketCount = newBucketCount;
 }
 
-static void printTableUsage(struct hashtable *t) {
-	for (uint64_t i = 0; i < t->size; ++i) {
-		printf("[%s]", t->data[i].used ? "x" : " ");
+static inline void insertElement(struct hashtable *hashtable, struct bucket **prev, const void *element, size_t elementSize, uint32_t hash) {
+	if (needsRehash(hashtable))
+		rehash(hashtable);
+	struct bucket *next = malloc(sizeof(struct bucket) + elementSize);
+	memcpy(&next->data, element, elementSize);
+	next->hash = hash;
+	next->next = *prev;
+	*prev = next;
+	hashtable->elemCount++;
+}
+
+static inline bool insertOrReplaceInHashtable(struct hashtable *hashtable, bool isInsert, const void *element, size_t elementSize, uint32_t hash) {
+	struct bucket **prev = &hashtable->buckets[hashToIndex(hashtable, hash)];
+	struct bucket *bucket = *prev;
+	while (bucket) {
+		if (bucket->hash == hash && hashtable->compare(&element, &bucket->data)) {
+			if (isInsert)
+				return false;
+			memcpy(&bucket->data, element, elementSize);
+			return true;
+		}
+		prev = &bucket->next;
+		bucket = bucket->next;
 	}
+	insertElement(hashtable, prev, element, elementSize, hash);
+	return true;
+}
+
+bool insertInHashtable(struct hashtable *hashtable, const void *element, size_t elementSize, uint32_t hash) {
+	return insertOrReplaceInHashtable(hashtable, true, element, elementSize, hash);
+}
+
+void replaceInHashtable(struct hashtable *hashtable, const void *element, size_t elementSize, uint32_t hash) {
+	insertOrReplaceInHashtable(hashtable, false, element, elementSize, hash);
+}
+
+void forceInsertInHashtable(struct hashtable *hashtable, const void *element, size_t elementSize, uint32_t hash) {
+	insertElement(hashtable, &hashtable->buckets[hashToIndex(hashtable, hash)], element, elementSize, hash);
+}
+
+bool removeFromHashtable(struct hashtable *hashtable, const void *element, uint32_t hash) {
+	struct bucket **prev = &hashtable->buckets[hashToIndex(hashtable, hash)];
+	struct bucket *bucket = *prev;
+	while (bucket) {
+		if (bucket->hash == hash && hashtable->compare(element, &bucket->data)) {
+			*prev = bucket->next;
+			free(bucket);
+			return true;
+		}
+		prev = &bucket->next;
+		bucket = bucket->next;
+	}
+	return false;
+}
+
+void freeHashtable(struct hashtable *hashtable) {
+	for (size_t i = 0, n = hashtable->bucketCount; i < n; ++i) {
+		struct bucket *bucket = hashtable->buckets[i];
+		while (bucket) {
+			struct bucket *next = bucket->next;
+			free(bucket);
+			bucket = next;
+		}
+	}
+}
+
+bool compareDatabaseEntry(const void* entry1, const void* entry2) {
+	return !strcmp(*(const char**)entry1, *(const char**)entry2);
+}
+
+struct constantsDatabase* newConstantsDatabase(void) {
+	return (struct constantsDatabase*)newHashtable(compareDatabaseEntry);
+}
+
+bool existsInDatabase(struct constantsDatabase *database, const char *key) {
+	return findInHashtable(&database->hashtable, key, hashString(hashInit(), key)) != NULL;
+}
+
+#define DATABASE_ACCESSORS(T, entryName, setterName, getterName, defaultValue) \
+	struct entryName { \
+		const char *key; \
+		void* toFree; \
+		T value; \
+	}; \
+	void setterName(struct constantsDatabase *database, const char *key, T value) { \
+		replaceInHashtable( \
+			&database->hashtable, \
+			&(struct entryName) { .key = stringCopy(key), .value = value }, \
+			sizeof(struct entryName), \
+			hashString(hashInit(), key)); \
+	} \
+	T getterName(struct constantsDatabase *database, const char *key) { \
+		struct entryName *entry = findInHashtable(&database->hashtable, key, hashString(hashInit(), key)); \
+		return entry ? entry->value : (defaultValue); \
+	}
+
+DATABASE_ACCESSORS(struct vector, vectorEntry, setDatabaseVector, getDatabaseVector, ((struct vector) { 0.0f, 0.0f, 0.0f }))
+DATABASE_ACCESSORS(float,         floatEntry,  setDatabaseFloat,  getDatabaseFloat,  0.0f)
+DATABASE_ACCESSORS(char*,         stringEntry, ignoreAccessor,    getDatabaseString, NULL)
+DATABASE_ACCESSORS(int,           intEntry,    setDatabaseInt,    getDatabaseInt,    0)
+
+void setDatabaseString(struct constantsDatabase *database, const char *key, const char *value) {
+	struct stringEntry *entry = findInHashtable(&database->hashtable, key, hashString(hashInit(), key));
+	char *valueCopy = stringCopy(value);
+	if (entry) {
+		// We need to free the existing string stored in the entry
+		free(entry->value);
+		entry->toFree = entry->value = valueCopy;
+	} else {
+		forceInsertInHashtable(
+			&database->hashtable,
+			&(struct stringEntry) { .key = stringCopy(key), .toFree = valueCopy, .value = valueCopy },
+			sizeof(struct stringEntry),
+			hashString(hashInit(), key));
+	}
+}
+
+void setDatabaseTag(struct constantsDatabase *database, const char *key) {
+	replaceInHashtable(&database->hashtable, &key, sizeof(const char*), hashString(hashInit(), key));
+}
+
+struct databaseEntry {
+	char *key;
+	void* toFree;
+};
+
+void freeConstantsDatabase(struct constantsDatabase *database) {
+	for (size_t i = 0, n = database->hashtable.bucketCount; i < n; ++i) {
+		struct bucket *bucket = database->hashtable.buckets[i];
+		while (bucket) {
+			struct databaseEntry *entry = (struct databaseEntry*)&bucket->data;
+			free(entry->key);
+			free(entry->toFree);
+			bucket = bucket->next;
+		}
+	}
+	freeHashtable(&database->hashtable);
+}
+
+static void printTableUsage(struct hashtable *hashtable) {
+	for (size_t i = 0, n = hashtable->bucketCount; i < n; ++i)
+		printf("[%s]", hashtable->buckets[i] ? "x" : " ");
 	printf("\n");
 }
 
 void testTable() {
-	struct hashtable *table = newTable();
-	
-	printTableUsage(table);
-	
-	setFloat(table, "Foo", 0.1f);
-	setFloat(table, "Bar", 0.2f);
-	setFloat(table, "Baz", 0.3f);
-	
-	printTableUsage(table);
-	
-	logr(debug, "Value at %s is %f\n", "Foo", getFloat(table, "Foo"));
-	logr(debug, "Value at %s is %f\n", "Bar", getFloat(table, "Bar"));
-	logr(debug, "Value at %s is %f\n", "Baz", getFloat(table, "Baz"));
-	
-	setFloat(table, "Baz", 0.4f);
-	logr(debug, "Value at %s is %f\n", "Baz", getFloat(table, "Baz"));
-	/*printUsage(table);
+	struct constantsDatabase *database = newConstantsDatabase();
+
+	printTableUsage(&database->hashtable);
+
+	setDatabaseFloat(database, "Foo", 0.1f);
+	setDatabaseFloat(database, "Bar", 0.2f);
+	setDatabaseFloat(database, "Baz", 0.3f);
+
+	printTableUsage(&database->hashtable);
+
+	logr(debug, "Value at %s is %f\n", "Foo", getDatabaseFloat(database, "Foo"));
+	logr(debug, "Value at %s is %f\n", "Bar", getDatabaseFloat(database, "Bar"));
+	logr(debug, "Value at %s is %f\n", "Baz", getDatabaseFloat(database, "Baz"));
+
+	setDatabaseFloat(database, "Baz", 0.4f);
+	logr(debug, "Value at %s is %f\n", "Baz", getDatabaseFloat(database, "Baz"));
+	printTableUsage(&database->hashtable);
 	for (int i = 0; i < 10000000; ++i) {
-		setFloat(table, "Yeet", 3.3333);
+		setDatabaseFloat(database, "Yeet", 3.3333);
 	}
-	printUsage(table);
-	*/
+	printTableUsage(&database->hashtable);
 	logr(debug, "Testing overfill\n");
 	char buf[5];
-	for (uint64_t i = 0; i < defaultTableSize; ++i) {
-		sprintf(buf, "%"PRIu64, i);
-		setFloat(table, buf, (float)i);
-		printTableUsage(table);
+	for (size_t i = 0, n = database->hashtable.bucketCount; i < n; ++i) {
+		sprintf(buf, "%zu", i);
+		setDatabaseFloat(database, buf, (float)i);
+		printTableUsage(&database->hashtable);
 	}
-	
-	freeTable(table);
+
+	freeConstantsDatabase(database);
 }

--- a/src/utils/hashtable.c
+++ b/src/utils/hashtable.c
@@ -10,7 +10,6 @@
 #include "hashtable.h"
 
 #include <inttypes.h>
-#include <assert.h>
 #include "logging.h"
 #include "../datatypes/vector.h"
 #include "assert.h"
@@ -59,7 +58,7 @@ struct hashtable* newHashtable(bool (*compare)(const void*, const void*)) {
 }
 
 static inline size_t hashToIndex(struct hashtable *hashtable, uint32_t hash) {
-	assert(isPowerOfTwo(hashtable->bucketCount));
+	ASSERT(isPowerOfTwo(hashtable->bucketCount));
 	return hash & (hashtable->bucketCount - 1);
 }
 

--- a/tests/test_hashtable.h
+++ b/tests/test_hashtable.h
@@ -12,49 +12,40 @@
 bool hashtable_mixed(void) {
 	bool pass = true;
 	
-	struct hashtable *table = newTable();
+	struct constantsDatabase *database = newConstantsDatabase();
 	
-	setVector(table, "key0", (struct vector){1.0f, 2.0f, 3.0f});
-	setFloat(table, "key1", 123.4f);
-	setTag(table, "key2");
-	setString(table, "key3", "This is my cool string");
-	setInt(table, "key4", 1234);
+	setDatabaseVector(database, "key0", (struct vector){1.0f, 2.0f, 3.0f});
+	setDatabaseFloat(database, "key1", 123.4f);
+	setDatabaseTag(database, "key2");
+	setDatabaseString(database, "key3", "This is my cool string");
+	setDatabaseInt(database, "key4", 1234);
 	
-	test_assert(table);
-	test_assert(vecEquals(getVector(table, "key0"), (struct vector){1.0f, 2.0f, 3.0f}));
-	test_assert(getFloat(table, "key1") == 123.4f);
-	test_assert(exists(table, "key2"));
-	test_assert(stringEquals(getString(table, "key3"), "This is my cool string"));
-	test_assert(getInt(table, "key4") == 1234);
+	test_assert(database);
+	test_assert(vecEquals(getDatabaseVector(database, "key0"), (struct vector){1.0f, 2.0f, 3.0f}));
+	test_assert(getDatabaseFloat(database, "key1") == 123.4f);
+	test_assert(existsInDatabase(database, "key2"));
+	test_assert(stringEquals(getDatabaseString(database, "key3"), "This is my cool string"));
+	test_assert(getDatabaseInt(database, "key4") == 1234);
 	
-	freeTable(table);
+	freeConstantsDatabase(database);
 	
 	return pass;
-}
-
-size_t used_count(struct hashtable *t) {
-	size_t used = 0;
-	for (size_t i = 0; i < t->size; ++i) {
-		if (t->data[i].used) used++;
-	}
-	return used;
 }
 
 bool hashtable_fill(void) {
 	bool pass = true;
 	
-	struct hashtable *table = newTable();
+	struct constantsDatabase *database = newConstantsDatabase();
 	
 	char buf[20];
 	
-	// Collides at i == 203
-	for (size_t i = 0; i < 200 && pass; ++i) {
-		test_assert(used_count(table) == i);
+	for (size_t i = 0; i < 400 && pass; ++i) {
+		test_assert(database->hashtable.elemCount == i);
 		sprintf(buf, "key%lu", i);
-		setTag(table, buf);
+		setDatabaseTag(database, buf);
 	}
 	
-	freeTable(table);
+	freeConstantsDatabase(database);
 	
 	return pass;
 }


### PR DESCRIPTION
This changes the hash table to be more generic and use chaining as a collision resolution policy, and renames the old API to "constantsDatabase", in order to avoid conflicts with existing code.