### PR TITLE
Improved instance bounding box computation

### DIFF
--- a/src/lib/accelerators/bvh.h
+++ b/src/lib/accelerators/bvh.h
@@ -25,6 +25,10 @@ struct bvh;
 /// Returns the bounding box of the root of the given BVH
 struct boundingBox get_root_bbox(const struct bvh *bvh);
 
+/// Returns the transformed bounding box of the BVH, using a better approximation than transforming
+/// the root bounding box.
+struct boundingBox get_transformed_root_bbox(const struct bvh *bvh, const struct matrix4x4 *);
+
 /// Builds a BVH for a given mesh
 /// @param mesh Mesh containing polygons to process
 /// @param count Amount of polygons given

--- a/src/lib/renderer/instance.c
+++ b/src/lib/renderer/instance.c
@@ -214,8 +214,7 @@ static void getMeshBBoxAndCenter(const struct instance *instance, struct boundin
 		mesh->rayOffset = 0.0f;
 		return;
 	}
-	*bbox = get_root_bbox(mesh->bvh);
-	tform_bbox(bbox, instance->composite.A);
+	*bbox = get_transformed_root_bbox(mesh->bvh, &instance->composite.A);
 	*center = bboxCenter(bbox);
 	mesh->rayOffset = rayOffset(*bbox);
 }


### PR DESCRIPTION
This improves the bounding box computation for mesh instances. This directly results in a decrease of surface area of up to 25% in some cases (e.g. rotated instances). The performance increase is more modest, in the order of 5%.