### PR TITLE
FreeBSD fixes

### DIFF
--- a/src/driver/sdl.c
+++ b/src/driver/sdl.c
@@ -220,7 +220,7 @@ struct sdl_window *win_try_init(struct sdl_prefs *prefs, int width, int height) 
 	w->sym->SDL_RenderSetScale(w->renderer, w->windowScale, w->windowScale);
 	//Init pixel texture
 	uint32_t format = SDL_PIXELFORMAT_ABGR8888;
-#if SDL_BYTEORDER == BIG_ENDIAN
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
 	format = SDL_PIXELFORMAT_RGBA8888;
 #endif
 	w->texture = w->sym->SDL_CreateTexture(w->renderer, format, SDL_TEXTUREACCESS_STREAMING, w->width, w->height);

--- a/src/driver/sdl.c
+++ b/src/driver/sdl.c
@@ -53,7 +53,7 @@ struct sdl_syms {
 
 static void *try_find_sdl2_lib(void) {
 	char *candidates[] = {
-		"libSDL2-2.0.so",
+		"libSDL2-2.0.so.0",
 		"libSDL2-2.0.0.dylib",
 		"/usr/local/lib/libSDL2.dylib",
 		"SDL2.dll",

--- a/src/driver/vendored/SDL2/SDL_endian.h
+++ b/src/driver/vendored/SDL2/SDL_endian.h
@@ -64,7 +64,7 @@ _m_prefetch(void *__P)
 #define SDL_BYTEORDER  BYTE_ORDER
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/endian.h>
-#define SDL_BYTEORDER  BYTE_ORDER
+#define SDL_BYTEORDER  _BYTE_ORDER
 /* predefs from newer gcc and clang versions: */
 #elif defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__) && defined(__BYTE_ORDER__)
 #if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)

--- a/src/lib/protocol/server.h
+++ b/src/lib/protocol/server.h
@@ -11,6 +11,7 @@
 #include <common/dyn_array.h>
 
 #ifndef WINDOWS
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #endif
 


### PR DESCRIPTION
With these OS portability fixes I can build and run c-ray with SDL2 on FreeBSD. In fact, I can run it on a Morello CheriBSD system, i.e. with hardware-enforced capability-based memory safety (provoked by https://x.com/vkoskiv/status/1928497354371486118):

![333b4f3e9f3d4a1bc2752ae14de7cdd73244d6d3](https://github.com/user-attachments/assets/e445056c-9cf6-435b-b43c-0e91b231b10f)

The SDL2 one might be an issue given it's touching vendored code; I don't know what your policy is there. I should probably upstream it either way.