### PR TITLE
Fix crash in top-to-bottom tile order

### DIFF
--- a/src/lib/datatypes/tile.c
+++ b/src/lib/datatypes/tile.c
@@ -134,7 +134,7 @@ static void reorder_top_to_bottom(struct render_tile **tiles) {
 	struct render_tile *temp = { 0 };
 	
 	for (unsigned i = 0; i < v_arr_len(*tiles); ++i)
-		v_arr_add(temp, *tiles[v_arr_len(*tiles) - i - 1]);
+		v_arr_add(temp, (*tiles)[v_arr_len(*tiles) - i - 1]);
 	
 	v_arr_free((*tiles));
 	*tiles = temp;


### PR DESCRIPTION
## Summary

Fixes a segmentation fault when using `tileOrder: "topToBottom"`.

## Reproduction

Set the `tileOrder` to `topToBottom`, then run:

```sh
./bin/c-ray input/hdr.json
```

## Backtrace

```gdb
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00005568436026b0 in reorder_top_to_bottom (tiles=<optimized out>) at src/lib/datatypes/tile.c:137
137                     v_arr_add(temp, *tiles[v_arr_len(*tiles) - i - 1]);
[Current thread is 1 (Thread 0x7f9aa6e35740 (LWP 58697))]
(gdb) bt
#0  0x00005568436026b0 in reorder_top_to_bottom (tiles=<optimized out>) at src/lib/datatypes/tile.c:137
#1  tiles_reorder (tileOrder=ro_top_to_bottom, tiles=0x7fff77c41cf8) at src/lib/datatypes/tile.c:230
#2  tile_quantize (width=<optimized out>, height=800, tile_w=64, tile_h=64, order=ro_top_to_bottom)
    at src/lib/datatypes/tile.c:122
#3  0x00005568435ead55 in renderer_render (r=0x55688236a610) at src/lib/renderer/renderer.c:152
#4  0x00005568435e94d7 in main (argc=<optimized out>, argv=<optimized out>) at src/driver/main.c:317
```

## Fix

Change the array access from:

```c
v_arr_add(temp, *tiles[v_arr_len(*tiles) - i - 1]);
```

to:

```c
v_arr_add(temp, (*tiles)[v_arr_len(*tiles) - i - 1]);
```
